### PR TITLE
Better handling of relative months and years

### DIFF
--- a/test/RelativeDateTest.py
+++ b/test/RelativeDateTest.py
@@ -43,12 +43,40 @@ class RelativeDateTester(TopydoTest.TopydoTest):
         self.assertEquals(result, date.today() + timedelta(weeks=1))
 
     def test_one_month(self):
-        result = relative_date_to_date('1m')
-        self.assertEquals(result, date.today() + timedelta(30))
+        test_date = date(2015, 1, 10)
+        result = relative_date_to_date('1m', test_date)
+        self.assertEquals(result, date(2015, 2, 10))
+
+    def test_one_month_ext(self):
+        test_date1 = date(2015, 1, 29)
+        test_date2 = date(2016, 1, 31)
+        test_date3 = date(2015, 12, 31)
+        test_date4 = date(2015, 7, 31)
+        test_date5 = date(2015, 10, 31)
+
+        result1 = relative_date_to_date('1m', test_date1)
+        result2 = relative_date_to_date('1m', test_date2)
+        result3 = relative_date_to_date('1m', test_date3)
+        result4 = relative_date_to_date('1m', test_date4)
+        result5 = relative_date_to_date('1m', test_date5)
+
+        self.assertEquals(result1, date(2015, 2, 28))
+        self.assertEquals(result2, date(2016, 2, 29))
+        self.assertEquals(result3, date(2016, 1, 31))
+        self.assertEquals(result4, date(2015, 8, 31))
+        self.assertEquals(result5, date(2015, 11, 30))
 
     def test_one_year(self):
-        result = relative_date_to_date('1y')
-        self.assertEquals(result, date.today() + timedelta(365))
+        test_date = date(2015, 1, 10)
+        result = relative_date_to_date('1y', test_date)
+        self.assertEquals(result, date(2016, 1, 10))
+
+    def test_leap_year(self):
+        test_date = date(2016, 2, 29)
+        result1 = relative_date_to_date('1y', test_date)
+        result2 = relative_date_to_date('4y', test_date)
+        self.assertEquals(result1, date(2017, 2, 28))
+        self.assertEquals(result2, date(2020, 2, 29))
 
     def test_zero_months(self):
         result = relative_date_to_date('0m')

--- a/topydo/lib/RelativeDate.py
+++ b/topydo/lib/RelativeDate.py
@@ -17,7 +17,15 @@
 """ This module deals with relative dates (2d, 5y, Monday, today, etc.) """
 
 from datetime import date, timedelta
+import calendar
 import re
+
+def _add_months(sourcedate, months):
+    month = sourcedate.month - 1 + months
+    year = sourcedate.year + month / 12
+    month = month % 12 + 1
+    day = min(sourcedate.day,calendar.monthrange(year,month)[1])
+    return date(year,month,day)
 
 def _convert_pattern(p_length, p_periodunit, p_offset=date.today()):
     """
@@ -33,11 +41,9 @@ def _convert_pattern(p_length, p_periodunit, p_offset=date.today()):
     elif p_periodunit == 'w':
         result = p_offset + timedelta(weeks=p_length)
     elif p_periodunit == 'm':
-        # we'll consider a month to be 30 days
-        result = p_offset + timedelta(30 * p_length)
+        result = _add_months(p_offset, p_length)
     elif p_periodunit == 'y':
-        # we'll consider a year to be 365 days (yeah, I'm aware of leap years)
-        result = p_offset + timedelta(365 * p_length)
+        result = _add_months(p_offset, p_length * 12)
 
     return result
 


### PR DESCRIPTION
- Increment months strictly: 01.01.2015 + 1m = 01.02.2015.
- If there are fewer days in target month, date is rounded down:
  31.10.2015 + 1m = 30.11.2015.
- Years are incremented as 12 months.
- Leap years are 366 days long: 01.03.2015 + 1y = 01.03.2016 (not
  29.02.2016 as it would have been if year was equal to 365d)