### PR TITLE
topydo edit won't work if EDITOR is unset

### DIFF
--- a/topydo/lib/EditCommand.py
+++ b/topydo/lib/EditCommand.py
@@ -29,7 +29,10 @@ class EditCommand(Command):
         if not super(EditCommand, self).execute():
             return False
 
-        editor = os.environ['EDITOR'] or 'vi'
+        try:
+            editor = os.environ['EDITOR'] or 'vi'
+        except(KeyError):
+            editor =  'vi'
         todo = config().todotxt()
 
         return call([editor, todo]) == 0


### PR DESCRIPTION
On some systems EDITOR is unset by default, so in such situation topydo
would throw KeyError exception instead of opening todo.txt in vi.