### PR TITLE
Add tests for EditCommand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url = "https://github.com/bram85/topydo",
     extras_require = {
         'ical': ['icalendar'],
+        'edit-cmd-tests': ['mock'],
     },
     entry_points= {
         'console_scripts': ['topydo = topydo.cli.Main:main'],

--- a/test/EditCommandTest.py
+++ b/test/EditCommandTest.py
@@ -1,0 +1,108 @@
+# Topydo - A todo.txt client written in Python.
+# Copyright (C) 2014 - 2015 Bram Schoenmakers <me@bramschoenmakers.nl>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import mock
+
+import CommandTest
+from topydo.lib.EditCommand import EditCommand
+from topydo.lib.TodoList import TodoList
+from topydo.lib.Todo import Todo
+
+class EditCommandTest(CommandTest.CommandTest):
+    def setUp(self):
+        super(EditCommandTest, self).setUp()
+        todos = [
+            "Foo id:1",
+            "Bar p:1 @test",
+            "Baz @test",
+        ]
+
+        self.todolist = TodoList(todos)
+
+
+    @mock.patch('topydo.lib.EditCommand.EditCommand._open_in_editor')
+    def test_edit1(self, mock_open_in_editor):
+        """ Preserve dependencies after editing. """
+        mock_open_in_editor.return_value = 0
+
+        command = EditCommand(["1"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertTrue(self.todolist.is_dirty())
+        self.assertEquals(self.errors, "")
+        self.assertEquals(str(self.todolist), "Bar p:1 @test\nBaz @test\nFoo id:1")
+
+    @mock.patch('topydo.lib.EditCommand.EditCommand._todos_from_temp')
+    @mock.patch('topydo.lib.EditCommand.EditCommand._open_in_editor')
+    def test_edit2(self, mock_open_in_editor, mock_todos_from_temp):
+        """ Edit some todo. """
+        mock_open_in_editor.return_value = 0
+        mock_todos_from_temp.return_value = [Todo('Lazy Cat')]
+
+        command = EditCommand(["Bar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertTrue(self.todolist.is_dirty())
+        self.assertEquals(self.errors, "")
+        self.assertEquals(str(self.todolist), "Foo id:1\nBaz @test\nLazy Cat")
+
+    def test_edit3(self):
+        """ Throw an error after invalid todo number given as argument. """
+        command = EditCommand(["FooBar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEquals(self.errors, "Invalid todo number given.\n")
+
+    def test_edit4(self):
+        """ Throw an error with pointing invalid argument. """
+        command = EditCommand(["Bar","4"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEquals(self.errors, "Invalid todo number given: 4.\n")
+
+    @mock.patch('topydo.lib.EditCommand.EditCommand._todos_from_temp')
+    @mock.patch('topydo.lib.EditCommand.EditCommand._open_in_editor')
+    def test_edit5(self, mock_open_in_editor, mock_todos_from_temp):
+        """ Don't let to delete todos acidentally while editing. """
+        mock_open_in_editor.return_value = 0
+        mock_todos_from_temp.return_value = [Todo('Only one line')]
+
+        command = EditCommand(["1","Bar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEquals(self.errors, "Number of edited todos is not equal to number of supplied todo IDs.\n")
+        self.assertEquals(str(self.todolist), "Foo id:1\nBar p:1 @test\nBaz @test")
+
+    @mock.patch('topydo.lib.EditCommand.EditCommand._todos_from_temp')
+    @mock.patch('topydo.lib.EditCommand.EditCommand._open_in_editor')
+    def test_edit_expr(self, mock_open_in_editor, mock_todos_from_temp):
+        """ Edit todos matching expression. """
+        mock_open_in_editor.return_value = 0
+        mock_todos_from_temp.return_value = [Todo('Lazy Cat'), Todo('Lazy Dog')]
+
+        command = EditCommand(["-e","@test"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertTrue(self.todolist.is_dirty())
+        self.assertEquals(self.errors, "")
+        self.assertEquals(str(self.todolist), "Foo id:1\nLazy Cat\nLazy Dog")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
So I've thought about testcases for EditCommand for some time now and here is the result. I used mock library, because it's the simplest way in my opinion to bypass all `subprocess` parts of functionality. Moreover mock is part of standard library since python >= 3.3.