### PR TITLE
Unicode fixes for prompt branch

### DIFF
--- a/test/DeleteCommandTest.py
+++ b/test/DeleteCommandTest.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from six import u
 
 from test.CommandTest import CommandTest
 from topydo.lib.Config import config
@@ -149,6 +150,15 @@ class DeleteCommandTest(CommandTest):
         self.assertFalse(self.todolist.is_dirty())
         self.assertEqual(self.output, "")
         self.assertEqual(self.errors, "Invalid todo number given: 99.\nInvalid todo number given: A.\n")
+
+    def test_multi_del5(self):
+        """ Throw an error with invalid argument containing special characters. """
+        command = DeleteCommand([u("Fo\u00d3B\u0105r"), "Bar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, u("Invalid todo number given: Fo\u00d3B\u0105r.\n"))
 
     def test_empty(self):
         command = DeleteCommand([], self.todolist, self.out, self.error)

--- a/test/DepriCommandTest.py
+++ b/test/DepriCommandTest.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from six import u
 
 from topydo.commands.DepriCommand import DepriCommand
 from test.CommandTest import CommandTest
@@ -92,6 +93,15 @@ class DepriCommandTest(CommandTest):
         self.assertFalse(self.todolist.is_dirty())
         self.assertFalse(self.output)
         self.assertEqual(self.errors, "Invalid todo number given: 99.\nInvalid todo number given: FooBar.\n")
+
+    def test_invalid4(self):
+        """ Throw an error with invalid argument containing special characters. """
+        command = DepriCommand([u("Fo\u00d3B\u0105r"), "Bar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertFalse(self.output)
+        self.assertEqual(self.errors, u("Invalid todo number given: Fo\u00d3B\u0105r.\n"))
 
     def test_empty(self):
         command = DepriCommand([], self.todolist, self.out, self.error)

--- a/test/DoCommandTest.py
+++ b/test/DoCommandTest.py
@@ -16,6 +16,7 @@
 
 from datetime import date, timedelta
 import unittest
+from six import u
 
 from topydo.commands.DoCommand import DoCommand
 from test.CommandTest import CommandTest
@@ -323,6 +324,14 @@ class DoCommandTest(CommandTest):
         command.execute()
 
         self.assertEqual(self.errors, "Invalid todo number given: 99.\nInvalid todo number given: 10.\n")
+
+    def test_multi_do6(self):
+        """ Throw an error with invalid argument containing special characters. """
+        command = DoCommand([u("Fo\u00d3B\u0105r"), "Bar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEqual(self.errors, u("Invalid todo number given: Fo\u00d3B\u0105r.\n"))
 
     def test_invalid_recurrence(self):
         """ Show error message when an item has an invalid recurrence pattern. """

--- a/test/EditCommandTest.py
+++ b/test/EditCommandTest.py
@@ -16,9 +16,10 @@
 
 import unittest
 import mock
+from six import u
 
 from topydo.commands.EditCommand import EditCommand
-from test.CommandTest import CommandTest
+from test.CommandTest import CommandTest, utf8
 from topydo.lib.TodoList import TodoList
 from topydo.lib.Todo import Todo
 
@@ -29,6 +30,7 @@ class EditCommandTest(CommandTest):
             "Foo id:1",
             "Bar p:1 @test",
             "Baz @test",
+            u("Fo\u00f3B\u0105\u017a"),
         ]
 
         self.todolist = TodoList(todos)
@@ -44,7 +46,7 @@ class EditCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.is_dirty())
         self.assertEqual(self.errors, "")
-        self.assertEqual(str(self.todolist), "Bar p:1 @test\nBaz @test\nFoo id:1")
+        self.assertEqual(str(self.todolist), utf8(u("Bar p:1 @test\nBaz @test\nFo\u00f3B\u0105\u017a\nFoo id:1")))
 
     @mock.patch('topydo.commands.EditCommand.EditCommand._todos_from_temp')
     @mock.patch('topydo.commands.EditCommand.EditCommand._open_in_editor')
@@ -58,7 +60,7 @@ class EditCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.is_dirty())
         self.assertEqual(self.errors, "")
-        self.assertEqual(str(self.todolist), "Foo id:1\nBaz @test\nLazy Cat")
+        self.assertEqual(str(self.todolist), utf8(u("Foo id:1\nBaz @test\nFo\u00f3B\u0105\u017a\nLazy Cat")))
 
     def test_edit3(self):
         """ Throw an error after invalid todo number given as argument. """
@@ -70,11 +72,11 @@ class EditCommandTest(CommandTest):
 
     def test_edit4(self):
         """ Throw an error with pointing invalid argument. """
-        command = EditCommand(["Bar", "4"], self.todolist, self.out, self.error, None)
+        command = EditCommand(["Bar", "5"], self.todolist, self.out, self.error, None)
         command.execute()
 
         self.assertFalse(self.todolist.is_dirty())
-        self.assertEqual(self.errors, "Invalid todo number given: 4.\n")
+        self.assertEqual(self.errors, "Invalid todo number given: 5.\n")
 
     @mock.patch('topydo.commands.EditCommand.EditCommand._todos_from_temp')
     @mock.patch('topydo.commands.EditCommand.EditCommand._open_in_editor')
@@ -88,7 +90,30 @@ class EditCommandTest(CommandTest):
 
         self.assertFalse(self.todolist.is_dirty())
         self.assertEqual(self.errors, "Number of edited todos is not equal to number of supplied todo IDs.\n")
-        self.assertEqual(str(self.todolist), "Foo id:1\nBar p:1 @test\nBaz @test")
+        self.assertEqual(str(self.todolist), utf8(u("Foo id:1\nBar p:1 @test\nBaz @test\nFo\u00f3B\u0105\u017a")))
+
+    def test_edit6(self):
+        """ Throw an error with invalid argument containing special characters. """
+        command = EditCommand([u("Fo\u00d3B\u0105r"), "Bar"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEqual(self.errors, u("Invalid todo number given: Fo\u00d3B\u0105r.\n"))
+
+    @mock.patch('topydo.commands.EditCommand.EditCommand._todos_from_temp')
+    @mock.patch('topydo.commands.EditCommand.EditCommand._open_in_editor')
+    def test_edit7(self, mock_open_in_editor, mock_todos_from_temp):
+        """ Edit todo with special characters. """
+        mock_open_in_editor.return_value = 0
+        mock_todos_from_temp.return_value = [Todo('Lazy Cat')]
+
+        command = EditCommand([u("Fo\u00f3B\u0105\u017a")], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertTrue(self.todolist.is_dirty())
+        self.assertEqual(self.errors, "")
+        self.assertEqual(str(self.todolist), utf8(u("Foo id:1\nBar p:1 @test\nBaz @test\nLazy Cat")))
+
 
     @mock.patch('topydo.commands.EditCommand.EditCommand._todos_from_temp')
     @mock.patch('topydo.commands.EditCommand.EditCommand._open_in_editor')
@@ -102,7 +127,7 @@ class EditCommandTest(CommandTest):
 
         self.assertTrue(self.todolist.is_dirty())
         self.assertEqual(self.errors, "")
-        self.assertEqual(str(self.todolist), "Foo id:1\nLazy Cat\nLazy Dog")
+        self.assertEqual(str(self.todolist), utf8(u("Foo id:1\nFo\u00f3B\u0105\u017a\nLazy Cat\nLazy Dog")))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/PostponeCommandTest.py
+++ b/test/PostponeCommandTest.py
@@ -16,6 +16,7 @@
 
 from datetime import date, timedelta
 import unittest
+from six import u
 
 from topydo.commands.PostponeCommand import PostponeCommand
 from test.CommandTest import CommandTest
@@ -218,6 +219,15 @@ class PostponeCommandTest(CommandTest):
         self.assertFalse(self.todolist.is_dirty())
         self.assertEqual(self.output, "")
         self.assertEqual(self.errors, "Invalid todo number given: Zoo.\nInvalid todo number given: 99.\nInvalid todo number given: 123.\n")
+
+    def test_postpone20(self):
+        """ Throw an error with invalid argument containing special characters. """
+        command = PostponeCommand([u("Fo\u00d3B\u0105r"), "Bar", "1d"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, u("Invalid todo number given: Fo\u00d3B\u0105r.\n"))
 
     def test_help(self):
         command = PostponeCommand(["help"], self.todolist, self.out, self.error)

--- a/test/PriorityCommandTest.py
+++ b/test/PriorityCommandTest.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from six import u
 
 from topydo.commands.PriorityCommand import PriorityCommand
 from test.CommandTest import CommandTest
@@ -117,6 +118,15 @@ class PriorityCommandTest(CommandTest):
         self.assertFalse(self.todolist.is_dirty())
         self.assertFalse(self.output)
         self.assertEqual(self.errors, command.usage() + "\n")
+
+    def test_invalid7(self):
+        """ Throw an error with invalid argument containing special characters. """
+        command = PriorityCommand([u("Fo\u00d3B\u0105r"), "Bar", "C"], self.todolist, self.out, self.error, None)
+        command.execute()
+
+        self.assertFalse(self.todolist.is_dirty())
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, u("Invalid todo number given: Fo\u00d3B\u0105r.\n"))
 
     def test_empty(self):
         command = PriorityCommand([], self.todolist, self.out, self.error)

--- a/topydo/commands/EditCommand.py
+++ b/topydo/commands/EditCommand.py
@@ -18,6 +18,8 @@ import os
 from subprocess import call, check_call, CalledProcessError
 import tempfile
 
+from six import u
+
 from topydo.commands.ListCommand import ListCommand
 from topydo.lib.MultiCommand import MultiCommand
 from topydo.lib.Config import config
@@ -77,7 +79,7 @@ class EditCommand(MultiCommand, ListCommand):
 
         if len(self.invalid_numbers) > 1 or len(self.invalid_numbers) > 0 and len(self.todos) > 0:
             for number in self.invalid_numbers:
-                errors.append("Invalid todo number given: {}.".format(number))
+                errors.append(u("Invalid todo number given: {}.").format(number))
         elif len(self.invalid_numbers) == 1 and len(self.todos) == 0:
             errors.append("Invalid todo number given.")
 

--- a/topydo/commands/EditCommand.py
+++ b/topydo/commands/EditCommand.py
@@ -18,7 +18,7 @@ import os
 from subprocess import call, check_call, CalledProcessError
 import tempfile
 
-from six import u
+from six import text_type, u
 
 from topydo.commands.ListCommand import ListCommand
 from topydo.lib.MultiCommand import MultiCommand
@@ -52,7 +52,7 @@ class EditCommand(MultiCommand, ListCommand):
     def _todos_to_temp(self):
         f = tempfile.NamedTemporaryFile()
         for todo in self.todos:
-            f.write((str(todo) + "\n").encode('utf-8'))
+            f.write((text_type(todo) + "\n").encode('utf-8'))
         f.seek(0)
 
         return f

--- a/topydo/lib/MultiCommand.py
+++ b/topydo/lib/MultiCommand.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from six import u
+
 from topydo.lib.Command import Command
 from topydo.lib.TodoListBase import InvalidTodoException
 
@@ -52,7 +54,7 @@ class MultiCommand(Command):
 
         if len(self.invalid_numbers) > 1 or len(self.invalid_numbers) > 0 and len(self.todos) > 0:
             for number in self.invalid_numbers:
-                errors.append("Invalid todo number given: {}.".format(number))
+                errors.append(u("Invalid todo number given: {}.").format(number))
         elif len(self.invalid_numbers) == 1 and len(self.todos) == 0:
             errors.append("Invalid todo number given.")
         elif len(self.todos) == 0 and len(self.invalid_numbers) == 0:


### PR DESCRIPTION
This fixes bugs with printing error messages about multiple invalid todo numbers and with saving todos to temp file in EditCommand.

Part of #21