### PR TITLE
Add todos from file with '-f' flag.

### DIFF
--- a/test/AddCommandTest.py
+++ b/test/AddCommandTest.py
@@ -16,7 +16,14 @@
 
 from datetime import date
 import unittest
-import mock
+
+# We're searching for 'mock'
+# pylint: disable=no-name-in-module
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from six import u
 from io import StringIO
 

--- a/test/AddCommandTest.py
+++ b/test/AddCommandTest.py
@@ -16,7 +16,9 @@
 
 from datetime import date
 import unittest
+import mock
 from six import u
+from io import StringIO
 
 from topydo.commands import AddCommand
 from topydo.commands import ListCommand
@@ -240,6 +242,21 @@ class AddCommandTest(CommandTest):
         command.execute()
 
         self.assertEqual(self.output, utf8(u("|  1| {} Special \u25c4\n").format(self.today)))
+        self.assertEqual(self.errors, "")
+
+    @mock.patch("topydo.commands.AddCommand.stdin", StringIO(u("Fo\u00f3 due:tod id:1\nB\u0105r before:1")))
+    def test_add_from_stdin(self):
+        command = AddCommand.AddCommand(["-f", "-"], self.todolist, self.out, self.error)
+        command.execute()
+
+        self.assertEqual(self.output, utf8(u("|  1| {tod} Fo\u00f3 due:{tod} id:1\n|  2| {tod} B\u0105r p:1\n".format(tod=self.today))))
+        self.assertEqual(self.errors, "")
+
+    def test_add_from_file(self):
+        command = AddCommand.AddCommand(["-f", "test/data/AddCommandTest-from_file.txt"], self.todolist, self.out, self.error)
+        command.execute()
+
+        self.assertEqual(self.output, utf8(u("|  1| {tod} Foo @fo\u00f3b\u0105r due:{tod} id:1\n|  2| {tod} Bar +baz t:{tod} p:1\n".format(tod=self.today))))
         self.assertEqual(self.errors, "")
 
     def test_help(self):

--- a/test/data/AddCommandTest-from_file.txt
+++ b/test/data/AddCommandTest-from_file.txt
@@ -1,0 +1,2 @@
+Foo @foóbąr due:tod id:1
+Bar +baz t:tod before:1

--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -20,6 +20,7 @@ from datetime import date
 import re
 from sys import stdin
 import codecs
+from os.path import expanduser
 
 from topydo.lib.Config import config
 from topydo.lib.Command import Command
@@ -43,7 +44,7 @@ class AddCommand(Command):
 
         for opt, value in opts:
             if opt == '-f':
-                self.from_file = value
+                self.from_file = expanduser(value)
 
         self.args = args
 

--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -19,6 +19,7 @@
 from datetime import date
 import re
 from sys import stdin
+import codecs
 
 from topydo.lib.Config import config
 from topydo.lib.Command import Command
@@ -100,9 +101,9 @@ class AddCommand(Command):
         if self.from_file == '-':
             f = stdin
         else:
-            f = open(self.from_file, 'r')
+            f = codecs.open(self.from_file, 'r', encoding='utf-8')
 
-        todos = f.read().decode('utf-8').splitlines()
+        todos = f.read().splitlines()
 
         return todos
 

--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -134,7 +134,10 @@ class AddCommand(Command):
                 self.error(self.usage())
 
     def usage(self):
-        return """Synopsis: add <text>"""
+        return """Synopsis:
+  add <text>
+  add -f <file>
+  add -f -"""
 
     def help(self):
         return """\
@@ -149,4 +152,6 @@ This subcommand automatically adds the creation date to the added item.
   todo number (not the dependency number).
 
   Example: add "Subtask partof:1"
+
+-f : Add todo items from specified <file> or from standard input.
 """

--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -18,6 +18,7 @@
 
 from datetime import date
 import re
+from sys import stdin
 
 from topydo.lib.Config import config
 from topydo.lib.Command import Command
@@ -34,14 +35,14 @@ class AddCommand(Command):
             p_args, p_todolist, p_out, p_err, p_prompt)
         self.text = ' '.join(p_args)
         self.todo = None
-        self.from_file = False
+        self.from_file = None
 
     def _process_flags(self):
-        opts, args = self.getopt('f')
+        opts, args = self.getopt('f:')
 
         for opt, value in opts:
             if opt == '-f':
-                self.from_file = True
+                self.from_file = value
 
         self.args = args
 
@@ -95,8 +96,12 @@ class AddCommand(Command):
 
         self.todo.set_creation_date(date.today())
 
-    def get_todos_from_file(self, p_filename):
-        f = open(p_filename, 'r')
+    def get_todos_from_file(self):
+        if self.from_file == '-':
+            f = stdin
+        else:
+            f = open(self.from_file, 'r')
+
         todos = f.read().decode('utf-8').splitlines()
 
         return todos
@@ -117,7 +122,7 @@ class AddCommand(Command):
         self._process_flags()
 
         if self.from_file:
-            new_todos = self.get_todos_from_file(self.args[0])
+            new_todos = self.get_todos_from_file()
 
             for todo in new_todos:
                 self._add_todo(todo)


### PR DESCRIPTION
Sometimes I don't have access to my todo.txt file, but I do want to save some todo items. In such cases I'm writing those items into some .txt file and later manually copy-paste them into proper todo.txt. However this way I can't benefit from topydo awesomeness (relative dates, dependencies etc.). This PR solves this issue. `AddCommand` will open file specified after '-f' flag and treat its every line as separate todo item, pre- and postprocessing it like it's done currently when adding todo item from cli.

This way we can put into foobar.txt:

```
test1 due:tom t:today @test
test2 due:fri @test before:test1
```

And topydo will do the rest with `topydo -f foobar.txt`.

I'll work on new tests (old ones should still be valid) and update synopsis once You'll review that enhancement.