### PR TITLE
Use unittest.mock wherever it's available

### DIFF
--- a/test/EditCommandTest.py
+++ b/test/EditCommandTest.py
@@ -16,6 +16,8 @@
 
 import unittest
 
+# We're searching for 'mock'
+# pylint: disable=no-name-in-module 
 try:
     from unittest import mock
 except ImportError:

--- a/test/EditCommandTest.py
+++ b/test/EditCommandTest.py
@@ -15,7 +15,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from six import u
 import os
 


### PR DESCRIPTION
Since python 3.3 `mock` is part of standard library. Let's try to use that before looking for third-party installation of it.

This way testing on systems with python>=3.3 should be a little bit easier.