### PR TITLE
Windows cmd - make no color mode not output any ANSI sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,24 @@
 *.pyc
 *.sw?
-build
-dist
 install
 .coverage
+
+# Distribution / packaging
+.Python
+env/
+env*/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Sublime Text
+*.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false  # run on new infrastructure
 language: python
 python:
   - "2.7"
@@ -9,6 +10,10 @@ install:
   - "pip install icalendar"
   - "pip install pylint"
 script: "./run-tests.sh"
+# Cache Dependencies
+cache:
+  directories:
+    - $HOME/travis/.cache/pip
 notifications:
   webhooks:
     urls:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,29 @@
 from setuptools import setup, find_packages
+import os
+import re
+import codecs
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+    # intentionally *not* adding an encoding option to open
+    return codecs.open(os.path.join(here, *parts), 'r').read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^VERSION = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name = "topydo",
     packages = find_packages(exclude=["test"]),
-    version = "0.5",
+    version = find_version('topydo', 'lib', 'Version.py'),
     description = "A command-line todo list application using the todo.txt format.",
     author = "Bram Schoenmakers",
     author_email = "me@bramschoenmakers.nl",

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -78,7 +78,7 @@ class ListCommand(ExpressionCommand):
         Prints the todos in the right format.
 
         Defaults to normal text output (with possible colors and other pretty
-        printing. If a format was specified on the commandline, this format is
+        printing). If a format was specified on the commandline, this format is
         sent to the output.
         """
 

--- a/topydo/lib/PrettyPrinterFilter.py
+++ b/topydo/lib/PrettyPrinterFilter.py
@@ -80,7 +80,7 @@ class PrettyPrinterColorFilter(PrettyPrinterFilter):
                                 ' ' + link_color + r'\2\3' + color,
                                 p_todo_str)
 
-        p_todo_str += NEUTRAL_COLOR
+            p_todo_str += NEUTRAL_COLOR
 
         return p_todo_str
 


### PR DESCRIPTION
Currently, on Windows `cmd.exe`, with `color=0` set in the configuration, it still outputs unprocessed ANSI control codes. This fixes that.

Before:

    |437| 2015-05-30 order biz cards←[0m

After:

    |437| 2015-05-30 order biz cards

---

This also adds a couple other improvements:

 - in `setup.py`, pull version number directly from main code base (in this case, from `topydo/lib/Version.py`)
 - upgrade to run on new Travis-CI infrastructure
 - more inclusive .gitignore

---

I looked at adding tests, but not sure how to get at the 'raw' output streams that would contain the unprocessed ANSI codes.
