### PR TITLE
Windows cmd 2 -- add color to output on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,24 @@
 *.pyc
 *.sw?
-build
-dist
 install
 .coverage
+
+# Distribution / packaging
+.Python
+env/
+env*/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Sublime Text
+*.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false  # run on new infrastructure
 language: python
 python:
   - "2.7"
@@ -9,6 +10,10 @@ install:
   - "pip install icalendar"
   - "pip install pylint"
 script: "./run-tests.sh"
+# Cache Dependencies
+cache:
+  directories:
+    - $HOME/travis/.cache/pip
 notifications:
   webhooks:
     urls:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
+conditional_dependencies = {
+    "colorama>=0.2.5": "win32" in sys.platform,
+}
+
+
 setup(
     name = "topydo",
     packages = find_packages(exclude=["test"]),
@@ -30,7 +35,7 @@ setup(
     url = "https://github.com/bram85/topydo",
     install_requires = [
         'six >= 1.9.0',
-    ],
+    ] + [p for p, cond in conditional_dependencies.items() if cond],
     extras_require = {
         'ical': ['icalendar'],
         'prompt-toolkit': ['prompt-toolkit >= 0.39'],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 import os
 import re
 import codecs
+import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,29 @@
 from setuptools import setup, find_packages
+import os
+import re
+import codecs
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def read(*parts):
+    # intentionally *not* adding an encoding option to open
+    return codecs.open(os.path.join(here, *parts), 'r').read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^VERSION = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name = "topydo",
     packages = find_packages(exclude=["test"]),
-    version = "0.5",
+    version = find_version('topydo', 'lib', 'Version.py'),
     description = "A command-line todo list application using the todo.txt format.",
     author = "Bram Schoenmakers",
     author_email = "me@bramschoenmakers.nl",

--- a/topydo/cli/UILoader.py
+++ b/topydo/cli/UILoader.py
@@ -20,6 +20,10 @@ import sys
 import getopt
 from topydo.cli.CLIApplicationBase import MAIN_OPTS, error
 from topydo.cli.CLI import CLIApplication
+# enable color on windows CMD
+if "win32" in sys.platform:
+    import colorama
+    colorama.init()
 
 def main():
     """ Main entry point of the CLI. """

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -78,7 +78,7 @@ class ListCommand(ExpressionCommand):
         Prints the todos in the right format.
 
         Defaults to normal text output (with possible colors and other pretty
-        printing. If a format was specified on the commandline, this format is
+        printing). If a format was specified on the commandline, this format is
         sent to the output.
         """
 

--- a/topydo/lib/PrettyPrinterFilter.py
+++ b/topydo/lib/PrettyPrinterFilter.py
@@ -80,7 +80,7 @@ class PrettyPrinterColorFilter(PrettyPrinterFilter):
                                 ' ' + link_color + r'\2\3' + color,
                                 p_todo_str)
 
-        p_todo_str += NEUTRAL_COLOR
+            p_todo_str += NEUTRAL_COLOR
 
         return p_todo_str
 


### PR DESCRIPTION
I offer this as a solution to #32. [colorama](https://pypi.python.org/pypi/colorama) is used. What `colorama` does is (on Windows) is take ANSI color sequences and convert them to Win32 API calls. On other platforms, it does nothing. In this case, I have also made it so `colorama` is only installed and called in Windows systems. In my experience, `colorama` is the simplest and easiest way to add cross-platform color command-line output.

This pull request builds on #48, although no changes in that pull request should be required to make this work.

Now pictures:

## Before
![before](https://cloud.githubusercontent.com/assets/1548809/9182059/abd5e620-3f65-11e5-9a26-988ac37ef8bc.png)

## After
![after](https://cloud.githubusercontent.com/assets/1548809/9182058/abd03004-3f65-11e5-9720-f2b5cdbf390b.png)
