### PR TITLE
Sanitize defaults in topydo.lib.Config._Config

### DIFF
--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -16,8 +16,8 @@
 
 import os
 
+from six import iteritems
 from six.moves import configparser
-
 
 class ConfigError(Exception):
     def __init__(self, p_text):
@@ -51,47 +51,60 @@ class _Config:
         ]
 
         self.defaults = {
-            # topydo
-            'default_command': 'ls',
-            'colors': '1',
-            'filename': 'todo.txt',
-            'archive_filename': 'done.txt',
-            'identifiers': 'linenumber',
-            'backup_count': '5',
+            'topydo': {
+                'default_command': 'ls',
+                'colors': '1',
+                'filename': 'todo.txt',
+                'archive_filename': 'done.txt',
+                'identifiers': 'linenumber',
+                'backup_count': '5',
+            },
 
-            # add
-            'auto_creation_date': '1',
+            'add': {
+                'auto_creation_date': '1',
+            },
 
-            # ls
-            'hide_tags': 'id,p,ical',
-            'indent': 0,
-            'list_limit': '-1',
+            'ls': {
+                'hide_tags': 'id,p,ical',
+                'indent': '0',
+                'list_limit': '-1',
+            },
 
-            # tags
-            'tag_start': 't',
-            'tag_due': 'due',
-            'tag_star': 'star',
+            'tags': {
+                'tag_start': 't',
+                'tag_due': 'due',
+                'tag_star': 'star',
+            },
 
-            # sort
-            'keep_sorted': '0',
-            'sort_string': 'desc:importance,due,desc:priority',
-            'ignore_weekends': '1',
+            'sort': {
+                'keep_sorted': '0',
+                'sort_string': 'desc:importance,due,desc:priority',
+                'ignore_weekends': '1',
+            },
 
-            # dep
-            'append_parent_projects': '0',
-            'append_parent_contexts': '0',
+            'dep': {
+                'append_parent_projects': '0',
+                'append_parent_contexts': '0',
+            },
 
-            # colorscheme
-            'project_color': 'red',
-            'context_color': 'magenta',
-            'metadata_color': 'green',
-            'link_color': 'cyan',
-            'priority_colors': 'A:cyan,B:yellow,C:blue',
+            'colorscheme': {
+                'project_color': 'red',
+                'context_color': 'magenta',
+                'metadata_color': 'green',
+                'link_color': 'cyan',
+                'priority_colors': 'A:cyan,B:yellow,C:blue',
+            },
         }
 
         self.config = {}
 
-        self.cp = configparser.ConfigParser(self.defaults)
+        self.cp = configparser.ConfigParser()
+
+        for section in self.defaults:
+            self.cp.add_section(section)
+
+            for option, value in iteritems(self.defaults[section]):
+                self.cp.set(section, option, value)
 
         files = [
             "/etc/topydo.conf",
@@ -129,7 +142,7 @@ class _Config:
         try:
             return self.cp.getboolean('topydo', 'colors')
         except ValueError:
-            return self.defaults['colors'] == '1'
+            return self.defaults['topydo']['colors'] == '1'
 
     def todotxt(self):
         return os.path.expanduser(self.cp.get('topydo', 'filename'))
@@ -147,25 +160,25 @@ class _Config:
                 value = 0
             return value
         except ValueError:
-            return int(self.defaults['backup_count'])
+            return int(self.defaults['topydo']['backup_count'])
 
     def list_limit(self):
         try:
             return self.cp.getint('ls', 'list_limit')
         except ValueError:
-            return int(self.defaults['list_limit'])
+            return int(self.defaults['ls']['list_limit'])
 
     def list_indent(self):
         try:
             return self.cp.getint('ls', 'indent')
         except ValueError:
-            return int(self.defaults['indent'])
+            return int(self.defaults['ls']['indent'])
 
     def keep_sorted(self):
         try:
             return self.cp.getboolean('sort', 'keep_sorted')
         except ValueError:
-            return self.defaults['keep_sorted'] == '1'
+            return self.defaults['sort']['keep_sorted'] == '1'
 
     def sort_string(self):
         return self.cp.get('sort', 'sort_string')
@@ -174,19 +187,19 @@ class _Config:
         try:
             return self.cp.getboolean('sort', 'ignore_weekends')
         except ValueError:
-            return self.defaults['ignore_weekends'] == '1'
+            return self.defaults['sort']['ignore_weekends'] == '1'
 
     def append_parent_projects(self):
         try:
             return self.cp.getboolean('dep', 'append_parent_projects')
         except ValueError:
-            return self.defaults['append_parent_projects'] == '1'
+            return self.defaults['dep']['append_parent_projects'] == '1'
 
     def append_parent_contexts(self):
         try:
             return self.cp.getboolean('dep', 'append_parent_contexts')
         except ValueError:
-            return self.defaults['append_parent_contexts'] == '1'
+            return self.defaults['dep']['append_parent_contexts'] == '1'
 
     def _get_tag(self, p_tag):
         try:
@@ -232,7 +245,7 @@ class _Config:
             else:
                 pri_colors_dict = _str_to_dict(pri_colors_str)
         except ValueError:
-            pri_colors_dict = _str_to_dict(self.defaults['priority_colors'])
+            pri_colors_dict = _str_to_dict(self.defaults['colorscheme']['priority_colors'])
 
         return pri_colors_dict
 
@@ -240,31 +253,31 @@ class _Config:
         try:
             return self.cp.get('colorscheme', 'project_color')
         except ValueError:
-            return int(self.defaults['project_color'])
+            return int(self.defaults['colorscheme']['project_color'])
 
     def context_color(self):
         try:
             return self.cp.get('colorscheme', 'context_color')
         except ValueError:
-            return int(self.defaults['context_color'])
+            return int(self.defaults['colorscheme']['context_color'])
 
     def metadata_color(self):
         try:
             return self.cp.get('colorscheme', 'metadata_color')
         except ValueError:
-            return int(self.defaults['metadata_color'])
+            return int(self.defaults['colorscheme']['metadata_color'])
 
     def link_color(self):
         try:
             return self.cp.get('colorscheme', 'link_color')
         except ValueError:
-            return int(self.defaults['link_color'])
+            return int(self.defaults['colorscheme']['link_color'])
 
     def auto_creation_date(self):
         try:
             return self.cp.getboolean('add', 'auto_creation_date')
         except ValueError:
-            return self.defaults['auto_creation_date'] == '1'
+            return self.defaults['add']['auto_creation_date'] == '1'
 
 def config(p_path=None, p_overrides=None):
     """


### PR DESCRIPTION
Using defaults as a parameter passed to the constructor of `configparser.ConfigParser` results in a presence of **all** options inside **every** section. It's very convenient in many use-cases, but not very much with our configuration model.

After this change only relevant options are present in each section, so:

`topydo.lib.Config.config().has_option('topydo', 'priority_colors')`

will now return `False` as 'priority_colors' resides in 'colorscheme' section and not in 'topydo'. Before this change it would return `True`.