### PR TITLE
Add %h and %H for sets of humanized dates

### DIFF
--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shlex
 
 from six import iteritems
 from six.moves import configparser
@@ -301,7 +302,7 @@ class _Config:
         alias_dict = dict()
 
         for alias, meaning in aliases:
-            meaning = meaning.split()
+            meaning = shlex.split(meaning)
             real_subcommand = meaning[0]
             alias_args = meaning[1:]
             alias_dict[alias] = (real_subcommand, alias_args)

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -29,3 +29,22 @@ def humanize_date(p_datetime):
     now = arrow.now()
     date = now.replace(day=p_datetime.day, month=p_datetime.month, year=p_datetime.year)
     return date.humanize()
+
+def humanize_dates(p_due=None, p_start=None, p_creation=None):
+    """
+    Returns string with humanized versions of p_due, p_start and p_creation
+    """
+    now = arrow.now()
+    dates_list = []
+    if p_creation:
+        dates_list.append(humanize_date(p_creation))
+    if p_due:
+        dates_list.append('due ' + humanize_date(p_due))
+    if p_start:
+        start = humanize_date(p_start)
+        if start.endswith('ago'):
+            dates_list.append('started ' + start)
+        else:
+            dates_list.append('starts in ' + start)
+
+    return ', '.join(dates_list)

--- a/topydo/lib/PrettyPrinterFilter.py
+++ b/topydo/lib/PrettyPrinterFilter.py
@@ -22,7 +22,7 @@ from six import u
 
 from topydo.lib.Colors import NEUTRAL_COLOR, Colors
 from topydo.lib.Config import config
-from topydo.lib.ListFormat import filler, humanize_date
+from topydo.lib.ListFormat import filler, humanize_date, humanize_dates
 
 
 class PrettyPrinterFilter(object):
@@ -148,21 +148,27 @@ class PrettyPrinterFormatFilter(PrettyPrinterFilter):
             # relative due date
             'D': lambda t: humanize_date(t.due_date()) if t.due_date() else '',
 
+            # relative dates:  due, start
+            'h': lambda t: humanize_dates(p_due=t.due_date(), p_start=t.start_date()),
+
+            # relative dates in form:  creation, due, start
+            'H': lambda t: humanize_dates(t.due_date(), t.start_date(), t.creation_date()),
+
             # todo ID
             'i': lambda t: str(self.todolist.number(t)),
 
             # todo ID pre-filled with 1 or 2 spaces if its length is <3
             'I': lambda t: filler(str(self.todolist.number(t)), 3),
 
-            # list of tags (spaces)
-            'K': lambda t: ' '.join([u('{}:{}').format(tag, value)
-                                     for tag, value in sorted(p_todo.tags()) if
-                                     tag not in config().hidden_tags()]),
-
             # list of tags (spaces) without due: and t:
             'k': lambda t: ' '.join([u('{}:{}').format(tag, value)
                                      for tag, value in sorted(p_todo.tags()) if
                                      tag not in config().hidden_tags() + [config().tag_start(), config().tag_due()]]),
+
+            # list of tags (spaces)
+            'K': lambda t: ' '.join([u('{}:{}').format(tag, value)
+                                     for tag, value in sorted(p_todo.tags()) if
+                                     tag not in config().hidden_tags()]),
 
             # priority
             'p': lambda t: t.priority() if t.priority() else '',


### PR DESCRIPTION
**%h** stands for: `due %D, starts in/started %S`
**%H** stands for: `%C, %h`

Yet another step to produce output compatible with #52. I've changed only 'threshold' to 'start' as it is shorter.