### PR TITLE
Properly split alias options wrapped in quotes

### DIFF
--- a/test/TestGetSubCommand.py
+++ b/test/TestGetSubCommand.py
@@ -38,13 +38,21 @@ class GetSubcommandTest(TopydoTest):
         self.assertTrue(issubclass(real_cmd, AddCommand))
         self.assertEqual(final_args, ["help"])
 
-    def test_alias(self):
+    def test_alias01(self):
         config("test/data/aliases.conf")
 
         args = ["foo"]
         real_cmd, final_args = get_subcommand(args)
         self.assertTrue(issubclass(real_cmd, DeleteCommand))
         self.assertEqual(final_args, ["-f", "test"])
+
+    def test_alias02(self):
+        config("test/data/aliases.conf")
+
+        args = ["format"]
+        real_cmd, final_args = get_subcommand(args)
+        self.assertTrue(issubclass(real_cmd, ListCommand))
+        self.assertEqual(final_args, ["-F", "|I| x c d {(}p{)} s k", "-n", "25"])
 
     def test_default_cmd01(self):
         args = ["bar"]

--- a/test/data/aliases.conf
+++ b/test/data/aliases.conf
@@ -1,3 +1,4 @@
 [aliases]
 foo = rm -f test
 baz = FooBar
+format = ls -F "|I| x c d {(}p{)} s k" -n 25

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shlex
 
 from six import iteritems
 from six.moves import configparser
@@ -300,7 +301,7 @@ class _Config:
         alias_dict = dict()
 
         for alias, meaning in aliases:
-            meaning = meaning.split()
+            meaning = shlex.split(meaning)
             real_subcommand = meaning[0]
             alias_args = meaning[1:]
             alias_dict[alias] = (real_subcommand, alias_args)


### PR DESCRIPTION
Fixed with `shlex`.