### PR TITLE
Add customizable right alignment in list_format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,16 @@ setup(
     url = "https://github.com/bram85/topydo",
     install_requires = [
         'six >= 1.9.0',
-        'arrow',
+        'arrow >= 0.7.0',
     ],
     extras_require = {
         ':sys_platform=="win32"': ['colorama>=0.2.5'],
-        ':python_version=="2.7"': ['ushlex'],
+        # shutil.get_terminal_size() was introduced in Python 3.3
+        ':python_version=="2.7"': [
+            'backports.shutil_get_terminal_size>=1.0.0',
+            'ushlex',
+        ],
+        ':python_version=="3.2"': ['backports.shutil_get_terminal_size>=1.0.0'],
         'ical': ['icalendar'],
         'prompt-toolkit': ['prompt-toolkit >= 0.53'],
         'edit-cmd-tests': ['mock'],

--- a/topydo.conf
+++ b/topydo.conf
@@ -15,7 +15,7 @@ auto_creation_date          = 1
 hide_tags                   = id,p,ical
 indent                      = 0
 list_limit                  = -1
-list_format                 = |%I| %x %{(}p{)} %c %s %k
+list_format                 = |%I| %x %{(}p{)} %c %s %k %{due:}d %{t:}t
 
 [tags]
 tag_start                   = t

--- a/topydo.conf
+++ b/topydo.conf
@@ -51,6 +51,7 @@ append_parent_contexts      = 0
 [aliases]
 ;showall = ls -x
 ;next = ls -n 1
+;top = ls -F '|%I| %x %p %S %k	%{(}H{)}'
 ;lsproj = lsprj
 ;listprj = lsprj
 ;listproj = lsprj

--- a/topydo/cli/Prompt.py
+++ b/topydo/cli/Prompt.py
@@ -24,8 +24,12 @@ from topydo.cli.CLIApplicationBase import CLIApplicationBase, error, usage
 from topydo.cli.TopydoCompleter import TopydoCompleter
 from prompt_toolkit.shortcuts import prompt
 from prompt_toolkit.history import InMemoryHistory
+from six import PY2
 
 from topydo.lib.Config import config, ConfigError
+
+if PY2:
+    import ushlex as shlex
 
 # First thing is to poke the configuration and check whether it's sane
 # The modules below may already read in configuration upon import, so

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -17,7 +17,8 @@
 from topydo.lib.Config import config
 from topydo.lib.ExpressionCommand import ExpressionCommand
 from topydo.lib.PrettyPrinter import pretty_printer_factory
-from topydo.lib.PrettyPrinterFilter import (PrettyPrinterHideTagFilter,
+from topydo.lib.PrettyPrinterFilter import (PrettyPrinterAlignFilter,
+                                            PrettyPrinterHideTagFilter,
                                             PrettyPrinterIndentFilter,
                                             PrettyPrinterFormatFilter)
 
@@ -92,6 +93,7 @@ class ListCommand(ExpressionCommand):
             filters = []
             filters.append(PrettyPrinterFormatFilter(self.todolist,
                            self.format))
+            filters.append(PrettyPrinterAlignFilter())
             filters.append(PrettyPrinterIndentFilter(indent))
             filters.append(PrettyPrinterHideTagFilter(hidden_tags))
 

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -74,7 +74,7 @@ class _Config:
                 'hide_tags': 'id,p,ical',
                 'indent': '0',
                 'list_limit': '-1',
-                'list_format': '|%I| %x %{(}p{)} %c %s %k',
+                'list_format': '|%I| %x %{(}p{)} %c %s %k %{due:}d %{t:}t',
             },
 
             'tags': {

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -52,3 +52,36 @@ def humanize_dates(p_due=None, p_start=None, p_creation=None):
             dates_list.append('starts in ' + start)
 
     return ', '.join(dates_list)
+
+def strip_placeholder_braces(p_matchobj):
+    """
+    Returns string with conditional braces around placeholder stripped and
+    percent sign glued into placeholder character.
+
+    Returned string is composed from 'start', 'before', 'placeholder', 'after',
+    'whitespace', and 'end' match-groups of p_matchobj. Conditional braces are
+    stripped from 'before' and 'after' groups. 'whitespace', 'start', and 'end'
+    groups are preserved without any change.
+
+    Using this function as an 'repl' argument in re.sub it is possible to turn:
+        %{(}B{)}
+    into:
+        (%B)
+    """
+    try:
+        before = p_matchobj.group('before').strip('{}')
+    except AttributeError:
+        before = ''
+
+    placeholder = p_matchobj.group('placeholder')
+
+    try:
+        after = p_matchobj.group('after').strip('{}')
+    except AttributeError:
+        after = ''
+
+    whitespace = p_matchobj.group('whitespace') or ''
+    start = p_matchobj.group('start') or ''
+    end = p_matchobj.group('end') or ''
+
+    return start + before + '%' + placeholder + after + whitespace + end

--- a/topydo/lib/PrettyPrinterFilter.py
+++ b/topydo/lib/PrettyPrinterFilter.py
@@ -163,15 +163,14 @@ class PrettyPrinterFormatFilter(PrettyPrinterFilter):
         # todo ID pre-filled with 1 or 2 spaces if its length is <3
         placeholders['I'] = lambda t: filler(str(self.todolist.number(t)), 3)
 
-        # list of tags (spaces) without due: and t:
+        # list of tags (spaces) without hidden ones and due: and t:
         placeholders['k'] = lambda t: ' '.join([u('{}:{}').format(tag, value)
                                     for tag, value in sorted(p_todo.tags()) if
                                     tag not in config().hidden_tags() + [config().tag_start(), config().tag_due()]])
 
-        # list of tags (spaces)
+        # list of all tags (spaces)
         placeholders['K'] = lambda t: ' '.join([u('{}:{}').format(tag, value)
-                                    for tag, value in sorted(p_todo.tags()) if
-                                    tag not in config().hidden_tags()])
+                                    for tag, value in sorted(p_todo.tags())])
 
         # priority
         placeholders['p'] = lambda t: t.priority() if t.priority() else ''
@@ -225,7 +224,8 @@ class PrettyPrinterFormatFilter(PrettyPrinterFilter):
                             text_lim = line_width - len(p_todo_str) - 4
                             p_todo_str = re.sub(re.escape(repl), repl[:text_lim] + '...', p_todo_str)
 
-        return p_todo_str
+        # cut trailing space left when last placeholder in p_todo_str is empty and its predecessor is not
+        return p_todo_str.rstrip()
 
 class PrettyPrinterAlignFilter(PrettyPrinterFilter):
     """


### PR DESCRIPTION
User can now mark place in list_format from where he wants to start
right-aligning remaining content. Tab character (\t) is used as marker.

Added also 'top' alias example to topydo.conf which utilizes this
feature and implements #52.

Minor: remove `- 1` from statements setting line width.