### PR TITLE
Fix unicode values in aliases config in python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     extras_require = {
         ':sys_platform=="win32"': ['colorama>=0.2.5'],
+        ':python_version=="2.7"': ['ushlex'],
         'ical': ['icalendar'],
         'prompt-toolkit': ['prompt-toolkit >= 0.53'],
         'edit-cmd-tests': ['mock'],

--- a/test/TestGetSubCommand.py
+++ b/test/TestGetSubCommand.py
@@ -54,6 +54,14 @@ class GetSubcommandTest(TopydoTest):
         self.assertTrue(issubclass(real_cmd, ListCommand))
         self.assertEqual(final_args, ["-F", "|I| x c d {(}p{)} s k", "-n", "25"])
 
+    def test_alias03(self):
+        config("test/data/aliases.conf")
+
+        args = ["smile"]
+        real_cmd, final_args = get_subcommand(args)
+        self.assertTrue(issubclass(real_cmd, ListCommand))
+        self.assertEqual(final_args, [u("\u263b")])
+
     def test_default_cmd01(self):
         args = ["bar"]
         real_cmd, final_args = get_subcommand(args)

--- a/test/data/aliases.conf
+++ b/test/data/aliases.conf
@@ -2,3 +2,4 @@
 foo = rm -f test
 baz = FooBar
 format = ls -F "|I| x c d {(}p{)} s k" -n 25
+smile = ls ☻

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -17,8 +17,12 @@
 import os
 import shlex
 
-from six import iteritems
+from six import iteritems, PY2
 from six.moves import configparser
+
+if PY2:
+    import ushlex as shlex
+    import codecs
 
 class ConfigError(Exception):
     def __init__(self, p_text):
@@ -132,7 +136,15 @@ class _Config:
         if p_path is not None:
             files = [p_path]
 
-        self.cp.read(files)
+        if PY2:
+            for path in files:
+                try:
+                    with codecs.open(path, 'r', encoding='utf-8') as f:
+                        self.cp.readfp(f)
+                except IOError:
+                    pass
+        else:
+            self.cp.read(files)
 
         self._supplement_sections()
 


### PR DESCRIPTION
Apparently `shlex` and `ConfigParser.read()` don't work well with Unicode
input in python2.