### PR TITLE
Clear ANSI codes before output length calculations

### DIFF
--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -648,5 +648,28 @@ Z   Z
 """
         self.assertEqual(self.output, result)
 
+    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    def test_list_format43(self, mock_terminal_size):
+        """ Colorblocks should not affect truncating or right_alignment. """
+        self.maxDiff = None
+        mock_terminal_size.return_value = self.terminal_size(100, 25)
+
+        config(p_overrides={('ls', 'list_format'): '%Z|%I| %x %p %S %k\\t%{(}h{)}'})
+        command1 = ListCommand(["-x"], self.todolist, self.out, self.error)
+        command1.execute()
+
+        config(p_overrides={('ls', 'list_format'): '%z|%I| %x %p %S %k\\t%{(}h{)}'})
+        command2 = ListCommand(["-x"], self.todolist, self.out, self.error)
+        command2.execute()
+
+        result = u""" |  1| D Bar @Context1 +Project2                             (due a month ago, started a month ago)
+ |  2| Z Lorem ipsum dolorem sit amet. Red @fox +jumpe... lazy:bar (due in 2 days, starts in a day)
+ |  3| C Foo @Context2 Not@Context +Project1 Not+Project
+ |  4| C Baz @Context1 +Project1 key:value
+ |  5| Drink beer @ home
+ |  6| x 2014-12-12 Completed but with date:2014-12-12
+"""
+        self.assertEqual(self.output, result * 2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -23,7 +23,7 @@ from six import u
 
 from topydo.lib.Config import config
 from topydo.lib.Colorblock import color_block
-from topydo.lib.Utils import get_terminal_size
+from topydo.lib.Utils import get_terminal_size, escape_ansi
 
 MAIN_PATTERN = (r'^({{(?P<before>.+?)}})?'
                 r'(?P<placeholder>{ph}|\[{ph}\])'
@@ -110,7 +110,7 @@ def _truncate(p_str, p_repl):
     Place of the truncation is calculated depending on p_max_width.
     """
     # 4 is for '...' and an extra space at the end
-    text_lim = _columns() - len(p_str) - 4
+    text_lim = _columns() - len(escape_ansi(p_str)) - 4
     truncated_str = re.sub(re.escape(p_repl), p_repl[:text_lim] + '...', p_str)
 
     return truncated_str
@@ -122,7 +122,7 @@ def _right_align(p_str):
     Right alignment is done using proper number of spaces calculated from
     'line_width' attribute.
     """
-    to_fill = _columns() - len(p_str)
+    to_fill = _columns() - len(escape_ansi(p_str))
 
     if to_fill > 0:
         p_str = re.sub('\t', ' '*to_fill, p_str)
@@ -272,7 +272,7 @@ class ListFormatParser(object):
         parsed_str = _unescape_percent_sign(''.join(parsed_list))
         parsed_str = _remove_redundant_spaces(parsed_str)
 
-        if self.one_line and len(parsed_str) >= _columns():
+        if self.one_line and len(escape_ansi(parsed_str)) >= _columns():
             parsed_str = _truncate(parsed_str, repl_trunc)
 
         if re.search('.*\t', parsed_str):


### PR DESCRIPTION
This fixes bug of truncating too much text if `%S` and `%Z` were used in list_format at the same time.