### PR TITLE
Fix priority colors when using colorblocks.

### DIFF
--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -122,49 +122,49 @@ class ColorsTest(TopydoTest):
 
     def test_priority_color1(self):
         config("test/data/ColorsTest1.conf")
-        color = Colors().get_priority_colors()
+        colors = Colors()
 
-        self.assertEqual(color['A'], '\033[0;38;5;1m')
-        self.assertEqual(color['B'], '\033[0;38;5;2m')
-        self.assertEqual(color['C'], '\033[0;38;5;3m')
+        self.assertEqual(colors.get_priority_color('A'), '\033[0;38;5;1m')
+        self.assertEqual(colors.get_priority_color('B'), '\033[0;38;5;2m')
+        self.assertEqual(colors.get_priority_color('C'), '\033[0;38;5;3m')
 
     def test_priority_color2(self):
         config("test/data/ColorsTest2.conf")
-        color = Colors().get_priority_colors()
+        colors = Colors()
 
-        self.assertEqual(color['A'], '\033[0;35m')
-        self.assertEqual(color['B'], '\033[0;1;36m')
-        self.assertEqual(color['C'], '\033[0;37m')
+        self.assertEqual(colors.get_priority_color('A'), '\033[0;35m')
+        self.assertEqual(colors.get_priority_color('B'), '\033[0;1;36m')
+        self.assertEqual(colors.get_priority_color('C'), '\033[0;37m')
 
     def test_priority_color3(self):
         config("test/data/ColorsTest3.conf")
-        color = Colors().get_priority_colors()
+        colors = Colors()
 
-        self.assertEqual(color['A'], '\033[0;35m')
-        self.assertEqual(color['B'], '\033[0;1;36m')
-        self.assertEqual(color['Z'], NEUTRAL_COLOR)
-        self.assertEqual(color['D'], '\033[0;31m')
-        self.assertEqual(color['C'], '\033[0;38;5;7m')
+        self.assertEqual(colors.get_priority_color('A'), '\033[0;35m')
+        self.assertEqual(colors.get_priority_color('B'), '\033[0;1;36m')
+        self.assertEqual(colors.get_priority_color('Z'), NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('D'), '\033[0;31m')
+        self.assertEqual(colors.get_priority_color('C'), '\033[0;38;5;7m')
 
     def test_priority_color4(self):
         config("test/data/ColorsTest4.conf")
-        color = Colors().get_priority_colors()
+        colors = Colors()
 
-        self.assertEqual(color['A'], NEUTRAL_COLOR)
-        self.assertEqual(color['B'], NEUTRAL_COLOR)
-        self.assertEqual(color['C'], NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('A'), NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('B'), NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('C'), NEUTRAL_COLOR)
 
     def test_empty_color_values(self):
         config("test/data/ColorsTest5.conf")
-        pri_color = Colors().get_priority_colors()
-        project_color = Colors().get_project_color()
-        context_color = Colors().get_context_color()
-        link_color = Colors().get_link_color()
-        metadata_color = Colors().get_metadata_color()
+        colors = Colors()
+        project_color = colors.get_project_color()
+        context_color = colors.get_context_color()
+        link_color = colors.get_link_color()
+        metadata_color = colors.get_metadata_color()
 
-        self.assertEqual(pri_color['A'], NEUTRAL_COLOR)
-        self.assertEqual(pri_color['B'], NEUTRAL_COLOR)
-        self.assertEqual(pri_color['C'], NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('A'), NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('B'), NEUTRAL_COLOR)
+        self.assertEqual(colors.get_priority_color('C'), NEUTRAL_COLOR)
         self.assertEqual(project_color, '')
         self.assertEqual(context_color, '')
         self.assertEqual(link_color, '')
@@ -172,15 +172,15 @@ class ColorsTest(TopydoTest):
 
     def test_empty_colorscheme(self):
         config("test/data/config1")
-        pri_color = Colors().get_priority_colors()
-        project_color = Colors().get_project_color()
-        context_color = Colors().get_context_color()
-        link_color = Colors().get_link_color()
-        metadata_color = Colors().get_metadata_color()
+        colors = Colors()
+        project_color = colors.get_project_color()
+        context_color = colors.get_context_color()
+        link_color = colors.get_link_color()
+        metadata_color = colors.get_metadata_color()
 
-        self.assertEqual(pri_color['A'], '\033[0;36m')
-        self.assertEqual(pri_color['B'], '\033[0;33m')
-        self.assertEqual(pri_color['C'], '\033[0;34m')
+        self.assertEqual(colors.get_priority_color('A'), '\033[0;36m')
+        self.assertEqual(colors.get_priority_color('B'), '\033[0;33m')
+        self.assertEqual(colors.get_priority_color('C'), '\033[0;34m')
         self.assertEqual(project_color, '\033[1;31m')
         self.assertEqual(context_color, '\033[1;35m')
         self.assertEqual(link_color, '\033[4;36m')

--- a/topydo/lib/Colorblock.py
+++ b/topydo/lib/Colorblock.py
@@ -16,7 +16,7 @@
 
 import re
 
-from topydo.lib.Colors import int_to_ansi, NEUTRAL_COLOR
+from topydo.lib.Colors import int_to_ansi, Colors
 from topydo.lib.Recurrence import relative_date_to_date
 
 COLOR16_RANGE = [
@@ -95,6 +95,7 @@ def progress_color_code(p_todo, p_safe=True):
 def color_block(p_todo, p_safe=True):
     color_code = progress_color_code(p_todo, p_safe)
     ansi_code = int_to_ansi(color_code, p_safe=p_safe, p_background=color_code)
+    priority_color = Colors().get_priority_color(p_todo.priority())
 
-    return '{} {}'.format(ansi_code, NEUTRAL_COLOR)
+    return '{} {}'.format(ansi_code, priority_color)
 

--- a/topydo/lib/Colors.py
+++ b/topydo/lib/Colors.py
@@ -59,80 +59,89 @@ def int_to_ansi(p_int, p_decorator='normal', p_safe=True, p_background=''):
     except ValueError:
         return None
 
+def _name_to_int(p_color_name):
+    """ Returns xterm color id from color name. """
+    color_names_dict = {
+            'black': 0,
+            'red': 1,
+            'green': 2,
+            'yellow': 3,
+            'blue': 4,
+            'magenta': 5,
+            'cyan': 6,
+            'gray': 7,
+            'darkgray': 8,
+            'light-red': 9,
+            'light-green': 10,
+            'light-yellow': 11,
+            'light-blue': 12,
+            'light-magenta': 13,
+            'light-cyan': 14,
+            'white': 15,
+    }
+
+    try:
+        return color_names_dict[p_color_name]
+    except KeyError:
+        return 404
+
+def _name_to_ansi(p_color_name, p_decorator):
+    """ Returns ansi color code from color name. """
+    number = _name_to_int(p_color_name)
+
+    return int_to_ansi(number, p_decorator)
+
+def _get_ansi(p_color, p_decorator):
+    """ Returns ansi color code from color name or xterm color id. """
+    if p_color == '':
+        ansi = ''
+    else:
+        ansi = int_to_ansi(p_color, p_decorator, False)
+
+        if not ansi:
+            ansi = _name_to_ansi(p_color, p_decorator)
+
+    return ansi
+
+def _get_priority_colors():
+    pri_ansi_colors = dict()
+    pri_colors = config().priority_colors()
+
+    for pri in pri_colors:
+        color = _get_ansi(pri_colors[pri], 'normal')
+
+        if color == '':
+            color = NEUTRAL_COLOR
+
+        pri_ansi_colors[pri] = color
+
+    return pri_ansi_colors
+
 
 class Colors(object):
     def __init__(self):
-        self.priority_colors = config().priority_colors()
+        self.priority_colors = _get_priority_colors()
         self.project_color = config().project_color()
         self.context_color = config().context_color()
         self.metadata_color = config().metadata_color()
         self.link_color = config().link_color()
 
-    def _name_to_int(self, p_color_name):
-        """ Returns xterm color id from color name. """
-        color_names_dict = {
-                'black': 0,
-                'red': 1,
-                'green': 2,
-                'yellow': 3,
-                'blue': 4,
-                'magenta': 5,
-                'cyan': 6,
-                'gray': 7,
-                'darkgray': 8,
-                'light-red': 9,
-                'light-green': 10,
-                'light-yellow': 11,
-                'light-blue': 12,
-                'light-magenta': 13,
-                'light-cyan': 14,
-                'white': 15,
-        }
-
-        try:
-            return color_names_dict[p_color_name]
-        except KeyError:
-            return 404
-
-    def _name_to_ansi(self, p_color_name, p_decorator):
-        """ Returns ansi color code from color name. """
-        number = self._name_to_int(p_color_name)
-
-        return int_to_ansi(number, p_decorator)
-
-    def _get_ansi(self, p_color, p_decorator):
-        """ Returns ansi color code from color name or xterm color id. """
-        if p_color == '':
-            ansi = ''
-        else:
-            ansi = int_to_ansi(p_color, p_decorator, False)
-
-            if not ansi:
-                ansi = self._name_to_ansi(p_color, p_decorator)
-
-        return ansi
-
-    def get_priority_colors(self):
-        pri_ansi_colors = dict()
-
-        for pri in self.priority_colors:
-            color = self._get_ansi(self.priority_colors[pri], 'normal')
-
-            if color == '':
-                color = NEUTRAL_COLOR
-
-            pri_ansi_colors[pri] = color
-
-        return pri_ansi_colors
-
     def get_project_color(self):
-        return self._get_ansi(self.project_color, 'bold')
+        return _get_ansi(self.project_color, 'bold')
 
     def get_context_color(self):
-        return self._get_ansi(self.context_color, 'bold')
+        return _get_ansi(self.context_color, 'bold')
 
     def get_metadata_color(self):
-        return self._get_ansi(self.metadata_color, 'bold')
+        return _get_ansi(self.metadata_color, 'bold')
 
     def get_link_color(self):
-        return self._get_ansi(self.link_color, 'underline')
+        return _get_ansi(self.link_color, 'underline')
+
+    def get_priority_color(self, p_priority):
+        try:
+            priority_color = self.priority_colors[p_priority]
+        except KeyError:
+            priority_color = NEUTRAL_COLOR
+
+        return priority_color

--- a/topydo/lib/prettyprinters/Colors.py
+++ b/topydo/lib/prettyprinters/Colors.py
@@ -34,17 +34,11 @@ class PrettyPrinterColorFilter(PrettyPrinterFilter):
         """ Applies the colors. """
         if config().colors():
             colorscheme = Colors()
-            priority_colors = colorscheme.get_priority_colors()
+            priority_color = colorscheme.get_priority_color(p_todo.priority())
             project_color = colorscheme.get_project_color()
             context_color = colorscheme.get_context_color()
             metadata_color = colorscheme.get_metadata_color()
             link_color = colorscheme.get_link_color()
-
-            priority_color = NEUTRAL_COLOR
-            try:
-                priority_color = priority_colors[p_todo.priority()]
-            except KeyError:
-                pass
 
             # color projects / contexts
             p_todo_str = re.sub(


### PR DESCRIPTION
Currently after colorblock neutral color code is inserted, as a result priority color is not printed adequately in output. This PR changes that and from now on colorblock is finished with relevant priority color.

This includes tiny refactoring of `Colors` class:
- move some functions outside of the class
- remove `Colors.get_priority_colors`
- add `Colors.get_priority_color`