### PR TITLE
Priority command: allow lowercase priorities to be input

### DIFF
--- a/test/test_priority_command.py
+++ b/test/test_priority_command.py
@@ -91,6 +91,16 @@ class PriorityCommandTest(CommandTest):
         self.assertEqual(self.output, "Priority changed from A to C\n|  1| (C) Foo\nPriority set to C.\n|  2| (C) Bar\n")
         self.assertEqual(self.errors, "")
 
+    def test_set_prio7(self):
+        """ Allow lowercase priority to be set. """
+        command = PriorityCommand(["Foo", "2", "c"], self.todolist, self.out,
+                                  self.error)
+        command.execute()
+
+        self.assertTrue(self.todolist.is_dirty())
+        self.assertEqual(self.output, "Priority changed from A to C\n|  1| (C) Foo\nPriority set to C.\n|  2| (C) Bar\n")
+        self.assertEqual(self.errors, "")
+
     def test_expr_prio1(self):
         command = PriorityCommand(["-e", "@test", "C"], self.todolist,
                                   self.out, self.error, None)

--- a/topydo/commands/PriorityCommand.py
+++ b/topydo/commands/PriorityCommand.py
@@ -22,7 +22,7 @@ from topydo.lib.Utils import is_valid_priority
 
 
 class PriorityCommand(MultiCommand):
-    def __init__(self, p_args, p_todolist, #pragma: no branch
+    def __init__(self, p_args, p_todolist,  # pragma: no branch
                  p_out=lambda a: None,
                  p_err=lambda a: None,
                  p_prompt=lambda a: None):
@@ -33,7 +33,7 @@ class PriorityCommand(MultiCommand):
 
     def _execute_multi_specific(self):
         def normalize_priority(p_priority):
-            match = re.search(r'\b([A-Z])\b', p_priority)
+            match = re.search(r'\b([A-Z])\b', p_priority.upper())
             return match.group(1) if match else p_priority
 
         priority = normalize_priority(self.args[-1])


### PR DESCRIPTION
Allow both upper- and lowercase priorities to be specified for the `pri` command. So these two commands (now) give the same results:

```
> topydo pri 2 D
> topydo pri 2 d
``` 