### PR TITLE
Introduce config file for column layout

### DIFF
--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -311,7 +311,6 @@ class _Config:
         """ Returns the list format used by `ls` """
         return self.cp.get('ls', 'list_format')
 
-
 def config(p_path=None, p_overrides=None):
     """
     Retrieve the config instance.

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -18,6 +18,9 @@ import configparser
 import os
 import shlex
 
+def home_config_path(p_filename):
+    return os.path.join(os.path.expanduser('~'), p_filename)
+
 class ConfigError(Exception):
     def __init__(self, p_text):
         self.text = p_text
@@ -120,7 +123,8 @@ class _Config:
 
         files = [
             "/etc/topydo.conf",
-            self._home_config_path(),
+            home_config_path('.config/topydo/config'),
+            home_config_path('.topydo'),
             ".topydo",
             "topydo.conf",
             "topydo.ini",
@@ -142,9 +146,6 @@ class _Config:
         for section in self.sections:
             if not self.cp.has_section(section):
                 self.cp.add_section(section)
-
-    def _home_config_path(self):
-        return os.path.join(os.path.expanduser('~'), '.topydo')
 
     def default_command(self):
         return self.cp.get('topydo', 'default_command')

--- a/topydo/ui/ColumnLayout.py
+++ b/topydo/ui/ColumnLayout.py
@@ -1,0 +1,58 @@
+# Topydo - A todo.txt client written in Python.
+# Copyright (C) 2014 - 2015 Bram Schoenmakers <me@bramschoenmakers.nl>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import configparser
+
+from topydo.lib.Config import home_config_path
+
+def columns():
+    """
+    Returns list with complete column configuration dicts.
+    """
+    def _get_column_dict(p_cp, p_column):
+        column_dict = dict()
+
+        column_dict['title'] = p_cp.get(p_column, 'title')
+        column_dict['filterexpr'] = p_cp.get(p_column, 'filterexpr')
+        column_dict['sortexpr'] = p_cp.get(p_column, 'sortexpr')
+        column_dict['show_all'] = p_cp.getboolean(p_column, 'show_all')
+
+        return column_dict
+
+    defaults = {
+            'title':  'Yet another column',
+            'filterexpr': '',
+            'sortexpr': 'desc:prio',
+            'show_all': '0',
+    }
+
+    cp = configparser.RawConfigParser(defaults)
+    files = [
+        "/etc/topydo_columns.conf",
+        home_config_path('.config/topydo/columns'),
+        home_config_path('.topydo_columns'),
+        ".topydo_columns",
+        "topydo_columns.conf",
+        "topydo_columns.ini",
+    ]
+
+    cp.read(files)
+    column_list = []
+
+    for column in cp.sections():
+        column_list.append(_get_column_dict(cp, column))
+
+    return column_list

--- a/topydo/ui/Main.py
+++ b/topydo/ui/Main.py
@@ -23,6 +23,7 @@ from topydo.ui.CommandLineWidget import CommandLineWidget
 from topydo.ui.ConsoleWidget import ConsoleWidget
 from topydo.ui.TodoListWidget import TodoListWidget
 from topydo.ui.ViewWidget import ViewWidget
+from topydo.ui.ColumnLayout import columns
 from topydo.lib.Config import config
 from topydo.lib.Sorter import Sorter
 from topydo.lib.Filter import get_filter_list, RelevanceFilter, DependencyFilter
@@ -318,13 +319,18 @@ class UIApplication(CLIApplicationBase):
         return user_input[0]
 
     def run(self):
-        dummy = {
-            "title": "View 1",
-            "sortexpr": "desc:prio",
-            "filterexpr": "",
-            "show_all": True,
-        }
-        self._add_column(self._viewdata_to_view(dummy))
+        layout = columns()
+        if len(layout) > 0:
+            for column in layout:
+                self._add_column(self._viewdata_to_view(column))
+        else:
+            dummy = {
+                "title": "All tasks",
+                "sortexpr": "desc:prio",
+                "filterexpr": "",
+                "show_all": True,
+            }
+            self._add_column(self._viewdata_to_view(dummy))
 
         self.mainloop.run()
 

--- a/topydo_columns.conf
+++ b/topydo_columns.conf
@@ -1,0 +1,12 @@
+[all]
+title = All tasks
+filterexpr = 
+
+[today]
+title = Due today
+filterexpr = due:tod
+
+[overdue]
+title = Overdue tasks
+filterexpr = due:<tod
+sortexpr = desc:due


### PR DESCRIPTION
Column-ui will look for columns configuration in:

1. system-wide configuration:
/etc/topydo_columns.conf

2. user dir:
~/.topydo_columns
~/.config/topydo/columns

2. current dir:
.topydo_columns
topydo_columns.conf
topydo_columns.ini

Each column should have its own INI style config section:

```ini
[FooBar]
title = Foo
filterexpr = Bar
sortexpr = desc:prio
show_all = 1
If any column option is missing, default value will be used.
```