### PR TITLE
New key-shortcuts for column-ui

### DIFF
--- a/topydo/ui/Main.py
+++ b/topydo/ui/Main.py
@@ -258,6 +258,7 @@ class UIApplication(CLIApplicationBase):
         no_output = lambda _: None
         urwid.connect_signal(todolist, 'execute_command',
                              lambda cmd: self._execute_handler(cmd, no_output))
+        urwid.connect_signal(todolist, 'refresh', self.mainloop.screen.clear)
 
         options = self.columns.options(
             width_type='given',

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -43,7 +43,7 @@ class TodoListWidget(urwid.LineBox):
 
         super().__init__(pile)
 
-        urwid.register_signal(TodoListWidget, ['execute_command'])
+        urwid.register_signal(TodoListWidget, ['execute_command', 'refresh'])
 
     @property
     def view(self):
@@ -134,7 +134,7 @@ class TodoListWidget(urwid.LineBox):
         elif p_key == 'e':
             self._edit_selected_item()
             # force screen redraw after editing
-            return self.listbox.keypress(p_size, 'ctrl l')
+            urwid.emit_signal(self, 'refresh')
         elif p_key == 'r':
             self.keystate = 'r'
         elif p_key == 'u':

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -104,10 +104,12 @@ class TodoListWidget(urwid.LineBox):
             # make sure to accept normal shortcuts again
             self.keystate = None
             return
-        elif self.keystate == 'p':
+        elif self.keystate in ['p', 'ps']:
             if p_key not in ['d', 'w', 'm', 'y']:
                 if p_key.isdigit():
                     self._pp_offset += p_key
+                elif self.keystate == 'p' and p_key == 's':
+                    self.keystate = 'ps'
                 else:
                     self._pp_offset = ''
                     self.keystate = None
@@ -184,7 +186,11 @@ class TodoListWidget(urwid.LineBox):
             self._pp_offset = '1'
 
         pattern = self._pp_offset + p_pattern
-        cmd_str = 'postpone {t_id} {pattern}'.format(t_id='{}', pattern=pattern)
+
+        if self.keystate == 'ps':
+            cmd_str = 'postpone -s {t_id} {pattern}'.format(t_id='{}', pattern=pattern)
+        else:
+            cmd_str = 'postpone {t_id} {pattern}'.format(t_id='{}', pattern=pattern)
 
         self._command_on_selected(cmd_str)
 

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -124,6 +124,8 @@ class TodoListWidget(urwid.LineBox):
             self.keystate = 'p'
         elif p_key == 'd':
             self._remove_selected_item()
+        elif p_key == 'u':
+            urwid.emit_signal(self, 'execute_command', "revert")
         elif p_key == 'j':
             self.listbox.keypress(p_size, 'down')
         elif p_key == 'k':

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -124,6 +124,10 @@ class TodoListWidget(urwid.LineBox):
             self.keystate = 'p'
         elif p_key == 'd':
             self._remove_selected_item()
+        elif p_key == 'e':
+            self._edit_selected_item()
+            # force screen redraw after editing
+            return self.listbox.keypress(p_size, 'ctrl l')
         elif p_key == 'u':
             urwid.emit_signal(self, 'execute_command', "revert")
         elif p_key == 'j':
@@ -182,6 +186,20 @@ class TodoListWidget(urwid.LineBox):
             self.view.todolist.number(todo)
 
             urwid.emit_signal(self, 'execute_command', "del {}".format(
+                str(self.view.todolist.number(todo))))
+        except AttributeError:
+            # No todo item selected
+            pass
+
+    def _edit_selected_item(self):
+        """
+        Opens the highlighted todo item in $EDITOR for editing.
+        """
+        try:
+            todo = self.listbox.focus.todo
+            self.view.todolist.number(todo)
+
+            urwid.emit_signal(self, 'execute_command', "edit {}".format(
                 str(self.view.todolist.number(todo))))
         except AttributeError:
             # No todo item selected

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -122,6 +122,8 @@ class TodoListWidget(urwid.LineBox):
             self._complete_selected_item()
         elif p_key == 'p':
             self.keystate = 'p'
+        elif p_key == 'd':
+            self._remove_selected_item()
         elif p_key == 'j':
             self.listbox.keypress(p_size, 'down')
         elif p_key == 'k':
@@ -165,6 +167,20 @@ class TodoListWidget(urwid.LineBox):
 
             urwid.emit_signal(self, 'execute_command', "postpone {} {}".format(
                 str(self.view.todolist.number(todo)), self._pp_offset + p_pattern))
+        except AttributeError:
+            # No todo item selected
+            pass
+
+    def _remove_selected_item(self):
+        """
+        Removes the highlighted todo item.
+        """
+        try:
+            todo = self.listbox.focus.todo
+            self.view.todolist.number(todo)
+
+            urwid.emit_signal(self, 'execute_command', "del {}".format(
+                str(self.view.todolist.number(todo))))
         except AttributeError:
             # No todo item selected
             pass

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -117,6 +117,11 @@ class TodoListWidget(urwid.LineBox):
                 self.keystate = None
 
             return
+        elif self.keystate == 'r':
+            if p_key.isalpha():
+                self._pri_selected_item(p_key)
+            self.keystate = None
+            return
 
         if p_key == 'x':
             self._complete_selected_item()
@@ -128,6 +133,8 @@ class TodoListWidget(urwid.LineBox):
             self._edit_selected_item()
             # force screen redraw after editing
             return self.listbox.keypress(p_size, 'ctrl l')
+        elif p_key == 'r':
+            self.keystate = 'r'
         elif p_key == 'u':
             urwid.emit_signal(self, 'execute_command', "revert")
         elif p_key == 'j':
@@ -204,3 +211,19 @@ class TodoListWidget(urwid.LineBox):
         except AttributeError:
             # No todo item selected
             pass
+
+    def _pri_selected_item(self, p_priority):
+        """
+        Sets the priority of the highlighted todo item with value from
+        p_priority.
+        """
+        try:
+            todo = self.listbox.focus.todo
+            self.view.todolist.number(todo)
+
+            urwid.emit_signal(self, 'execute_command', "pri {} {}".format(
+                str(self.view.todolist.number(todo)), p_priority))
+        except AttributeError:
+            # No todo item selected
+            pass
+

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -153,19 +153,27 @@ class TodoListWidget(urwid.LineBox):
     def selectable(self):
         return True
 
+    def _command_on_selected(self, p_cmd_str):
+        """
+        Executes command specified by p_cmd_str on selected todo item.
+
+        p_cmd_str should be string with one replacement field ('{}') which will
+        be substituted by id of selected todo item.
+        """
+        try:
+            todo = self.listbox.focus.todo
+            todo_id = str(self.view.todolist.number(todo))
+
+            urwid.emit_signal(self, 'execute_command', p_cmd_str.format(todo_id))
+        except AttributeError:
+            # No todo item selected
+            pass
+
     def _complete_selected_item(self):
         """
         Marks the highlighted todo item as complete.
         """
-        try:
-            todo = self.listbox.focus.todo
-            self.view.todolist.number(todo)
-
-            urwid.emit_signal(self, 'execute_command', "do {}".format(
-                str(self.view.todolist.number(todo))))
-        except AttributeError:
-            # No todo item selected
-            pass
+        self._command_on_selected('do {}')
 
     def _postpone_selected_item(self, p_pattern):
         """
@@ -174,56 +182,29 @@ class TodoListWidget(urwid.LineBox):
         """
         if self._pp_offset == '':
             self._pp_offset = '1'
-        try:
-            todo = self.listbox.focus.todo
-            self.view.todolist.number(todo)
 
-            urwid.emit_signal(self, 'execute_command', "postpone {} {}".format(
-                str(self.view.todolist.number(todo)), self._pp_offset + p_pattern))
-        except AttributeError:
-            # No todo item selected
-            pass
+        pattern = self._pp_offset + p_pattern
+        cmd_str = 'postpone {t_id} {pattern}'.format(t_id='{}', pattern=pattern)
+
+        self._command_on_selected(cmd_str)
 
     def _remove_selected_item(self):
         """
         Removes the highlighted todo item.
         """
-        try:
-            todo = self.listbox.focus.todo
-            self.view.todolist.number(todo)
-
-            urwid.emit_signal(self, 'execute_command', "del {}".format(
-                str(self.view.todolist.number(todo))))
-        except AttributeError:
-            # No todo item selected
-            pass
+        self._command_on_selected('del {}')
 
     def _edit_selected_item(self):
         """
         Opens the highlighted todo item in $EDITOR for editing.
         """
-        try:
-            todo = self.listbox.focus.todo
-            self.view.todolist.number(todo)
-
-            urwid.emit_signal(self, 'execute_command', "edit {}".format(
-                str(self.view.todolist.number(todo))))
-        except AttributeError:
-            # No todo item selected
-            pass
+        self._command_on_selected('edit {}')
 
     def _pri_selected_item(self, p_priority):
         """
         Sets the priority of the highlighted todo item with value from
         p_priority.
         """
-        try:
-            todo = self.listbox.focus.todo
-            self.view.todolist.number(todo)
+        cmd_str = 'pri {t_id} {priority}'.format(t_id='{}', priority=p_priority)
 
-            urwid.emit_signal(self, 'execute_command', "pri {} {}".format(
-                str(self.view.todolist.number(todo)), p_priority))
-        except AttributeError:
-            # No todo item selected
-            pass
-
+        self._command_on_selected(cmd_str)


### PR DESCRIPTION
### Quick reference:


- **r\<priority\>** = `topydo pri TODO <priority>`
- **e** = `topydo edit TODO`
- **u** = `topydo revert`
- **p\<offset\>\<pattern\>** = `topydo postpone TODO <offset><pattern>` - *\<offset\>* is string of digits. *\<pattern\>* is one of *d*, *w*, *m*, *y*.
- **p\<pattern\>** = `topydo postpone TODO 1<pattern>`
- **d** = `topydo rm TODO`

### Selected examples:

- **ra** sets todo item priority to *A*.
- **p3y** postpones todo item  by 3 years.
- **p20d** postpones todo item by 20 days.
- **pw** postpones todo item by one week (same as **p1w**)