### PR TITLE
Execute commands on multiple items + repeat command

### DIFF
--- a/topydo.conf
+++ b/topydo.conf
@@ -79,6 +79,7 @@ x = cmd do {}
 pp = postpone
 ps = postpone_s
 pr = pri
+m = mark
 0 = first_column
 $ = last_column
 h = prev_column

--- a/topydo.conf
+++ b/topydo.conf
@@ -93,3 +93,4 @@ L = swap_left
 R = swap_right
 <Left> = prev_column
 <Right> = next_column
+<Esc> = reset

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -125,6 +125,7 @@ class _Config:
                 'e': 'cmd edit {}',
                 'u': 'cmd revert',
                 'x': 'cmd do {}',
+                'm': 'mark',
                 'pp': 'postpone',
                 'ps': 'postpone_s',
                 'pr': 'pri',

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -142,6 +142,7 @@ class _Config:
                 'R': 'swap_right',
                 '<Left>': 'prev_column',
                 '<Right>': 'next_column',
+                '<Esc>': 'reset',
             },
         }
 

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -126,6 +126,7 @@ class _Config:
                 'u': 'cmd revert',
                 'x': 'cmd do {}',
                 'm': 'mark',
+                '.': 'repeat',
                 'pp': 'postpone',
                 'ps': 'postpone_s',
                 'pr': 'pri',

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -60,12 +60,10 @@ class TodoListWidget(urwid.LineBox):
                                                'refresh',
                                                'add_pending_action',
                                                'remove_pending_action',
-                                               'save_cmd',
                                                'repeat_cmd',
                                                'column_action',
                                                'show_keystate',
                                                'toggle_mark',
-                                               'has_marked_todos',
                                                ])
 
     @property
@@ -229,13 +227,7 @@ class TodoListWidget(urwid.LineBox):
             todo = self.listbox.focus.todo
             todo_id = str(self.view.todolist.number(todo))
 
-            result = urwid.emit_signal(self, 'has_marked_todos')
-            if result:
-                cmd = p_cmd_str
-            else:
-                cmd = p_cmd_str.format(todo_id)
-
-            urwid.emit_signal(self, p_execute_signal, cmd)
+            urwid.emit_signal(self, p_execute_signal, p_cmd_str, todo_id)
 
             # force screen redraw after editing
             if p_cmd_str.startswith('edit'):
@@ -262,8 +254,6 @@ class TodoListWidget(urwid.LineBox):
                 self._execute_on_selected(cmd, execute_signal)
             else:
                 urwid.emit_signal(self, execute_signal, cmd)
-
-            urwid.emit_signal(self, 'save_cmd', cmd, execute_signal)
         else:
             self.execute_builtin_action(p_action_str, p_size)
 
@@ -365,7 +355,4 @@ class TodoListWidget(urwid.LineBox):
         except AttributeError:
             todo_id = None
 
-        result = urwid.emit_signal(self, 'has_marked_todos')
-        if result:
-            todo_id = None
         urwid.emit_signal(self, 'repeat_cmd', todo_id)

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -64,8 +64,8 @@ class TodoListWidget(urwid.LineBox):
                                                'repeat_cmd',
                                                'column_action',
                                                'show_keystate',
-                                               'append_pending_todos',
-                                               'check_pending_todos',
+                                               'toggle_mark',
+                                               'has_marked_todos',
                                                ])
 
     @property
@@ -203,11 +203,11 @@ class TodoListWidget(urwid.LineBox):
     def selectable(self):
         return True
 
-    def _append_pending_todos(self):
+    def _toggle_marked_status(self):
         try:
             todo = self.listbox.focus.todo
             todo_id = str(self.view.todolist.number(todo))
-            result = urwid.emit_signal(self, 'append_pending_todos', todo_id)
+            result = urwid.emit_signal(self, 'toggle_mark', todo_id)
             attr_spec = {None: markup(todo, result)}
             self.listbox.focus.widget.set_attr_map(attr_spec)
         except AttributeError:
@@ -228,7 +228,7 @@ class TodoListWidget(urwid.LineBox):
             todo = self.listbox.focus.todo
             todo_id = str(self.view.todolist.number(todo))
 
-            result = urwid.emit_signal(self, 'check_pending_todos')
+            result = urwid.emit_signal(self, 'has_marked_todos')
             if result:
                 cmd = p_cmd_str
             else:
@@ -303,7 +303,7 @@ class TodoListWidget(urwid.LineBox):
         elif p_action_str == 'pri':
             pass
         elif p_action_str == 'mark':
-            self._append_pending_todos()
+            self._toggle_marked_status()
         elif p_action_str == 'repeat':
             self._repeat_cmd()
 
@@ -364,7 +364,7 @@ class TodoListWidget(urwid.LineBox):
         except AttributeError:
             todo_id = None
 
-        result = urwid.emit_signal(self, 'check_pending_todos')
+        result = urwid.emit_signal(self, 'has_marked_todos')
         if result:
             todo_id = None
         urwid.emit_signal(self, 'repeat_cmd', todo_id)

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -60,6 +60,8 @@ class TodoListWidget(urwid.LineBox):
                                                'refresh',
                                                'add_pending_action',
                                                'remove_pending_action',
+                                               'save_cmd',
+                                               'repeat_cmd',
                                                'column_action',
                                                'show_keystate',
                                                'append_pending_todos',
@@ -259,6 +261,8 @@ class TodoListWidget(urwid.LineBox):
                 self._execute_on_selected(cmd, execute_signal)
             else:
                 urwid.emit_signal(self, execute_signal, cmd)
+
+            urwid.emit_signal(self, 'save_cmd', cmd, execute_signal)
         else:
             self.execute_builtin_action(p_action_str, p_size)
 
@@ -270,7 +274,7 @@ class TodoListWidget(urwid.LineBox):
         'first_column', 'last_column', 'prev_column', 'next_column',
         'append_column', 'insert_column', 'edit_column', 'delete_column',
         'copy_column', swap_right', 'swap_left', 'postpone', 'postpone_s',
-        'pri', 'mark' and 'reset'.
+        'pri', 'mark', 'reset' and 'repeat'.
         """
         column_actions = ['first_column',
                           'last_column',
@@ -300,6 +304,8 @@ class TodoListWidget(urwid.LineBox):
             pass
         elif p_action_str == 'mark':
             self._append_pending_todos()
+        elif p_action_str == 'repeat':
+            self._repeat_cmd()
 
     def _add_pending_action(self, p_action, p_size):
         """
@@ -350,3 +356,15 @@ class TodoListWidget(urwid.LineBox):
             self._pp_offset = None
             result = False
         return result
+
+    def _repeat_cmd(self):
+        try:
+            todo = self.listbox.focus.todo
+            todo_id = str(self.view.todolist.number(todo))
+        except AttributeError:
+            todo_id = None
+
+        result = urwid.emit_signal(self, 'check_pending_todos')
+        if result:
+            todo_id = None
+        urwid.emit_signal(self, 'repeat_cmd', todo_id)

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -64,7 +64,6 @@ class TodoListWidget(urwid.LineBox):
                                                'show_keystate',
                                                'append_pending_todos',
                                                'check_pending_todos',
-                                               'clear_pending_todos',
                                                ])
 
     @property
@@ -270,8 +269,8 @@ class TodoListWidget(urwid.LineBox):
         Currently supported actions are: 'up', 'down', 'home', 'end',
         'first_column', 'last_column', 'prev_column', 'next_column',
         'append_column', 'insert_column', 'edit_column', 'delete_column',
-        'copy_column', swap_right', 'swap_left', 'postpone', 'postpone_s', 'pri'
-        and 'mark'.
+        'copy_column', swap_right', 'swap_left', 'postpone', 'postpone_s',
+        'pri', 'mark' and 'reset'.
         """
         column_actions = ['first_column',
                           'last_column',
@@ -284,6 +283,7 @@ class TodoListWidget(urwid.LineBox):
                           'copy_column',
                           'swap_left',
                           'swap_right',
+                          'reset',
                           ]
 
         if p_action_str in column_actions:

--- a/topydo/ui/TodoListWidget.py
+++ b/topydo/ui/TodoListWidget.py
@@ -16,7 +16,7 @@
 
 import urwid
 
-from topydo.ui.TodoWidget import TodoWidget, markup
+from topydo.ui.TodoWidget import TodoWidget
 from topydo.lib.Utils import translate_key_to_config
 
 
@@ -207,9 +207,10 @@ class TodoListWidget(urwid.LineBox):
         try:
             todo = self.listbox.focus.todo
             todo_id = str(self.view.todolist.number(todo))
-            result = urwid.emit_signal(self, 'toggle_mark', todo_id)
-            attr_spec = {None: markup(todo, result)}
-            self.listbox.focus.widget.set_attr_map(attr_spec)
+            if urwid.emit_signal(self, 'toggle_mark', todo_id):
+                self.listbox.focus.mark()
+            else:
+                self.listbox.focus.unmark()
         except AttributeError:
             # No todo item selected
             pass

--- a/topydo/ui/TodoWidget.py
+++ b/topydo/ui/TodoWidget.py
@@ -35,7 +35,8 @@ def _to_urwid_color(p_color):
     else:
         return 'h{}'.format(p_color.color)
 
-def _markup(p_todo, p_focus):
+
+def markup(p_todo, p_focus):
     """
     Returns an attribute spec for the colors that correspond to the given todo
     item.
@@ -83,8 +84,8 @@ class TodoWidget(urwid.WidgetWrap):
 
         self.widget = urwid.AttrMap(
             self.columns,
-            _markup(p_todo, False), # no focus
-            _markup(p_todo, True) # focus
+            markup(p_todo, False),  # no focus
+            markup(p_todo, True)  # focus
         )
 
         super().__init__(self.widget)

--- a/topydo/ui/TodoWidget.py
+++ b/topydo/ui/TodoWidget.py
@@ -36,7 +36,7 @@ def _to_urwid_color(p_color):
         return 'h{}'.format(p_color.color)
 
 
-def markup(p_todo, p_focus):
+def _markup(p_todo, p_focus):
     """
     Returns an attribute spec for the colors that correspond to the given todo
     item.
@@ -84,8 +84,8 @@ class TodoWidget(urwid.WidgetWrap):
 
         self.widget = urwid.AttrMap(
             self.columns,
-            markup(p_todo, False),  # no focus
-            markup(p_todo, True)  # focus
+            _markup(p_todo, False),  # no focus
+            _markup(p_todo, True)  # focus
         )
 
         super().__init__(self.widget)
@@ -100,3 +100,9 @@ class TodoWidget(urwid.WidgetWrap):
     def selectable(self):
         # make sure that ListBox will highlight this widget
         return True
+
+    def mark(self):
+        self.widget.set_attr_map({None: _markup(self.todo, True)})
+
+    def unmark(self):
+        self.widget.set_attr_map({None: _markup(self.todo, False)})


### PR DESCRIPTION
1. *m* is the default key for toggling 'marked' items.
2. Marking works now across all columns.
3. \<Esc\> will clear the whole selection.
4. Command will be executed on **all** items in **all** columns.
5. *.* repeats last command on currently selected item or marked items.
6. *repeat* remembers silent/verbose output.

I'm using it daily for about 2 weeks and didn't find any major bug. The only minor drawback is that *mark* action uses the same `markup` function so there is no visual difference between *focused* and *marked*. I didn't decide just yet how to deal with it. I see 2 solutions:

1. Use other colors to show *marked* status.
2. Extend current `markup` function to visualize focus on *marked* items differently than on unmarked ones.