### PR TITLE
Temporarily disable color output in column-ui's console

### DIFF
--- a/topydo/ui/Main.py
+++ b/topydo/ui/Main.py
@@ -70,6 +70,8 @@ class UIApplication(CLIApplicationBase):
     def __init__(self):
         super().__init__()
 
+        config(p_overrides={('topydo', 'colors'): '0'}) # disable color in output
+
         self.todofile = TodoFile.TodoFile(config().todotxt())
         self.todolist = TodoList.TodoList(self.todofile.read())
 


### PR DESCRIPTION
We don't want raw ANSI codes there. We'll enable it back again after providing proper coloring solution.