### PR TITLE
Don't concatenate column layout configs

### DIFF
--- a/topydo/ui/ColumnLayout.py
+++ b/topydo/ui/ColumnLayout.py
@@ -41,15 +41,18 @@ def columns():
 
     cp = configparser.RawConfigParser(defaults)
     files = [
-        "/etc/topydo_columns.conf",
-        home_config_path('.config/topydo/columns'),
-        home_config_path('.topydo_columns'),
-        ".topydo_columns",
-        "topydo_columns.conf",
         "topydo_columns.ini",
+        "topydo_columns.conf",
+        ".topydo_columns",
+        home_config_path('.topydo_columns'),
+        home_config_path('.config/topydo/columns'),
+        "/etc/topydo_columns.conf",
     ]
 
-    cp.read(files)
+    for filename in files:
+        if cp.read(filename):
+            break
+
     column_list = []
 
     for column in cp.sections():


### PR DESCRIPTION
Use only one layout file. Following precedence is applied:
1. Local (i.e. $PWD/.topydo_columns or
   $PWD/topydo_columns.conf or $PWD/topydo_columns.ini
2. User's home (i.e. $HOME/.topydo_columns or
   $HOME/.config/topydo/columns)
3. System-wide (i.e. /etc/topydo_columns.conf)