### PR TITLE
Return color config values as integers and update tests for colors

### DIFF
--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -19,152 +19,194 @@
 import unittest
 
 from test.topydo_testcase import TopydoTest
-from topydo.lib.Colors import NEUTRAL_COLOR, Colors
+from topydo.lib.Colors import (get_ansi_color, NEUTRAL_COLOR, CONTEXT_COLOR,
+                               METADATA_COLOR, LINK_COLOR, PRIORITY_COLOR,
+                               PROJECT_COLOR)
 from topydo.lib.Config import config
+from topydo.lib.Todo import Todo
 
 
 class ColorsTest(TopydoTest):
     def test_project_color1(self):
         config(p_overrides={('colorscheme', 'project_color'): '2'})
-        color = Colors().get_project_color()
+        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;38;5;2m')
 
     def test_project_color2(self):
         config(p_overrides={('colorscheme', 'project_color'): 'Foo'})
-        color = Colors().get_project_color()
+        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_project_color3(self):
         config(p_overrides={('colorscheme', 'project_color'): 'yellow'})
-        color = Colors().get_project_color()
+        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;33m')
 
     def test_project_color4(self):
         config(p_overrides={('colorscheme', 'project_color'): '686'})
-        color = Colors().get_project_color()
+        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_context_color1(self):
         config(p_overrides={('colorscheme', 'context_color'): '35'})
-        color = Colors().get_context_color()
+        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;38;5;35m')
 
     def test_context_color2(self):
         config(p_overrides={('colorscheme', 'context_color'): 'Bar'})
-        color = Colors().get_context_color()
+        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_context_color3(self):
         config(p_overrides={('colorscheme', 'context_color'): 'magenta'})
-        color = Colors().get_context_color()
+        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;35m')
 
     def test_context_color4(self):
         config(p_overrides={('colorscheme', 'context_color'): '392'})
-        color = Colors().get_context_color()
+        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_metadata_color1(self):
         config(p_overrides={('colorscheme', 'metadata_color'): '128'})
-        color = Colors().get_metadata_color()
+        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;38;5;128m')
 
     def test_metadata_color2(self):
         config(p_overrides={('colorscheme', 'metadata_color'): 'Baz'})
-        color = Colors().get_metadata_color()
+        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_metadata_color3(self):
         config(p_overrides={('colorscheme', 'metadata_color'): 'light-red'})
-        color = Colors().get_metadata_color()
+        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;1;31m')
 
     def test_metadata_color4(self):
         config(p_overrides={('colorscheme', 'metadata_color'): '777'})
-        color = Colors().get_metadata_color()
+        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_link_color1(self):
         config(p_overrides={('colorscheme', 'link_color'): '77'})
-        color = Colors().get_link_color()
+        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
 
         self.assertEqual(color, '\033[4;38;5;77m')
 
     def test_link_color2(self):
         config(p_overrides={('colorscheme', 'link_color'): 'FooBar'})
-        color = Colors().get_link_color()
+        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_link_color3(self):
         config(p_overrides={('colorscheme', 'link_color'): 'red'})
-        color = Colors().get_link_color()
+        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
 
         self.assertEqual(color, '\033[4;31m')
 
     def test_link_color4(self):
         config(p_overrides={('colorscheme', 'link_color'): '777'})
-        color = Colors().get_link_color()
+        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
 
-        self.assertEqual(color, NEUTRAL_COLOR)
+        self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR))
 
     def test_priority_color1(self):
         config("test/data/ColorsTest1.conf")
-        colors = Colors()
+        todo_a = Todo('(A) Foo')
+        todo_b = Todo('(B) Bar')
+        todo_c = Todo('(C) FooBar')
 
-        self.assertEqual(colors.get_priority_color('A'), '\033[0;38;5;1m')
-        self.assertEqual(colors.get_priority_color('B'), '\033[0;38;5;2m')
-        self.assertEqual(colors.get_priority_color('C'), '\033[0;38;5;3m')
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+
+        self.assertEqual(color_a, '\033[0;38;5;1m')
+        self.assertEqual(color_b, '\033[0;38;5;2m')
+        self.assertEqual(color_c, '\033[0;38;5;3m')
 
     def test_priority_color2(self):
         config("test/data/ColorsTest2.conf")
-        colors = Colors()
+        todo_a = Todo('(A) Foo')
+        todo_b = Todo('(B) Bar')
+        todo_c = Todo('(C) FooBar')
 
-        self.assertEqual(colors.get_priority_color('A'), '\033[0;35m')
-        self.assertEqual(colors.get_priority_color('B'), '\033[0;1;36m')
-        self.assertEqual(colors.get_priority_color('C'), '\033[0;37m')
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+
+        self.assertEqual(color_a, '\033[0;35m')
+        self.assertEqual(color_b, '\033[0;1;36m')
+        self.assertEqual(color_c, '\033[0;37m')
 
     def test_priority_color3(self):
         config("test/data/ColorsTest3.conf")
-        colors = Colors()
+        todo_a = Todo('(A) Foo')
+        todo_b = Todo('(B) Bar')
+        todo_z = Todo('(C) FooBar')
+        todo_d = Todo('(C) Baz')
+        todo_c = Todo('(C) FooBaz')
 
-        self.assertEqual(colors.get_priority_color('A'), '\033[0;35m')
-        self.assertEqual(colors.get_priority_color('B'), '\033[0;1;36m')
-        self.assertEqual(colors.get_priority_color('Z'), NEUTRAL_COLOR)
-        self.assertEqual(colors.get_priority_color('D'), '\033[0;31m')
-        self.assertEqual(colors.get_priority_color('C'), '\033[0;38;5;7m')
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
+        color_z = get_ansi_color(PRIORITY_COLOR, todo_z, True)
+        color_d = get_ansi_color(PRIORITY_COLOR, todo_d, True)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+
+        self.assertEqual(color_a, '\033[0;35m')
+        self.assertEqual(color_b, '\033[0;1;36m')
+        self.assertEqual(color_z, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_d, '\033[0;31m')
+        self.assertEqual(color_c, '\033[0;38;5;7m')
 
     def test_priority_color4(self):
         config("test/data/ColorsTest4.conf")
-        colors = Colors()
+        todo_a = Todo('(A) Foo')
+        todo_b = Todo('(B) Bar')
+        todo_c = Todo('(C) FooBar')
 
-        self.assertEqual(colors.get_priority_color('A'), NEUTRAL_COLOR)
-        self.assertEqual(colors.get_priority_color('B'), NEUTRAL_COLOR)
-        self.assertEqual(colors.get_priority_color('C'), NEUTRAL_COLOR)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+
+        self.assertEqual(color_a, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_b, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_c, get_ansi_color(NEUTRAL_COLOR))
 
     def test_empty_color_values(self):
         config("test/data/ColorsTest5.conf")
-        colors = Colors()
-        project_color = colors.get_project_color()
-        context_color = colors.get_context_color()
-        link_color = colors.get_link_color()
-        metadata_color = colors.get_metadata_color()
+        project_color = get_ansi_color(PROJECT_COLOR, None, True,
+                                       p_decoration='bold')
+        context_color = get_ansi_color(CONTEXT_COLOR, None, True,
+                                       p_decoration='bold')
+        link_color = get_ansi_color(LINK_COLOR, None, True,
+                                    p_decoration='underline')
+        metadata_color = get_ansi_color(METADATA_COLOR, None, True,
+                                        p_decoration='bold')
 
-        self.assertEqual(colors.get_priority_color('A'), NEUTRAL_COLOR)
-        self.assertEqual(colors.get_priority_color('B'), NEUTRAL_COLOR)
-        self.assertEqual(colors.get_priority_color('C'), NEUTRAL_COLOR)
+        todo_a = Todo('(A) Foo')
+        todo_b = Todo('(B) Bar')
+        todo_c = Todo('(C) FooBar')
+
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+
+        self.assertEqual(color_a, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_b, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_c, get_ansi_color(NEUTRAL_COLOR))
         self.assertEqual(project_color, '')
         self.assertEqual(context_color, '')
         self.assertEqual(link_color, '')
@@ -172,15 +214,26 @@ class ColorsTest(TopydoTest):
 
     def test_empty_colorscheme(self):
         config("test/data/config1")
-        colors = Colors()
-        project_color = colors.get_project_color()
-        context_color = colors.get_context_color()
-        link_color = colors.get_link_color()
-        metadata_color = colors.get_metadata_color()
+        project_color = get_ansi_color(PROJECT_COLOR, None, True,
+                                       p_decoration='bold')
+        context_color = get_ansi_color(CONTEXT_COLOR, None, True,
+                                       p_decoration='bold')
+        link_color = get_ansi_color(LINK_COLOR, None, True,
+                                    p_decoration='underline')
+        metadata_color = get_ansi_color(METADATA_COLOR, None, True,
+                                        p_decoration='bold')
 
-        self.assertEqual(colors.get_priority_color('A'), '\033[0;36m')
-        self.assertEqual(colors.get_priority_color('B'), '\033[0;33m')
-        self.assertEqual(colors.get_priority_color('C'), '\033[0;34m')
+        todo_a = Todo('(A) Foo')
+        todo_b = Todo('(B) Bar')
+        todo_c = Todo('(C) FooBar')
+
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+
+        self.assertEqual(color_a, '\033[0;36m')
+        self.assertEqual(color_b, '\033[0;33m')
+        self.assertEqual(color_c, '\033[0;34m')
         self.assertEqual(project_color, '\033[1;31m')
         self.assertEqual(context_color, '\033[1;35m')
         self.assertEqual(link_color, '\033[4;36m')

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -247,7 +247,10 @@ class _Config:
             pri_colors_dict = dict()
             for pri_color in p_string.split(','):
                 pri, color = pri_color.split(':')
-                pri_colors_dict[pri] = color
+                try:
+                    pri_colors_dict[pri] = int(color)
+                except ValueError:
+                    pri_colors_dict[pri] = color
 
             return pri_colors_dict
 
@@ -263,27 +266,27 @@ class _Config:
 
     def project_color(self):
         try:
-            return self.cp.get('colorscheme', 'project_color')
+            return self.cp.getint('colorscheme', 'project_color')
         except ValueError:
-            return int(self.defaults['colorscheme']['project_color'])
+            return self.defaults['colorscheme']['project_color']
 
     def context_color(self):
         try:
-            return self.cp.get('colorscheme', 'context_color')
+            return self.cp.getint('colorscheme', 'context_color')
         except ValueError:
-            return int(self.defaults['colorscheme']['context_color'])
+            return self.defaults['colorscheme']['context_color']
 
     def metadata_color(self):
         try:
-            return self.cp.get('colorscheme', 'metadata_color')
+            return self.cp.getint('colorscheme', 'metadata_color')
         except ValueError:
-            return int(self.defaults['colorscheme']['metadata_color'])
+            return self.defaults['colorscheme']['metadata_color']
 
     def link_color(self):
         try:
-            return self.cp.get('colorscheme', 'link_color')
+            return self.cp.getint('colorscheme', 'link_color')
         except ValueError:
-            return int(self.defaults['colorscheme']['link_color'])
+            return self.defaults['colorscheme']['link_color']
 
     def auto_creation_date(self):
         try:


### PR DESCRIPTION
Tests are runnable again.

So far I see 2 problems (thanks to updated tests):

- [ ] numerical values above 255 are processed as normal, instead of returning default or `NEUTRAL_COLOR` resulting in something like `\x1b[4;38;5;777m` for config value `777`.
- [ ] We need some config value to turn 256 color palette on/off as we previously used 256 by default for numerical values and 16 color palette for text values. Right now there is no method (as far as I can see) to get 256 color-palette for ls output.