### PR TITLE
Recover previous ansi-color functionality

### DIFF
--- a/test/test_colors.py
+++ b/test/test_colors.py
@@ -29,97 +29,101 @@ from topydo.lib.Todo import Todo
 class ColorsTest(TopydoTest):
     def test_project_color1(self):
         config(p_overrides={('colorscheme', 'project_color'): '2'})
-        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(PROJECT_COLOR, p_todo=None, p_decoration='bold')
 
-        self.assertEqual(color, '\033[1;38;5;2m')
+        self.assertEqual(color, '\033[1;32m')
 
     def test_project_color2(self):
         config(p_overrides={('colorscheme', 'project_color'): 'Foo'})
-        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(PROJECT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_project_color3(self):
         config(p_overrides={('colorscheme', 'project_color'): 'yellow'})
-        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(PROJECT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;33m')
 
     def test_project_color4(self):
         config(p_overrides={('colorscheme', 'project_color'): '686'})
-        color = get_ansi_color(PROJECT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(PROJECT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_context_color1(self):
         config(p_overrides={('colorscheme', 'context_color'): '35'})
-        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(CONTEXT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;38;5;35m')
 
     def test_context_color2(self):
         config(p_overrides={('colorscheme', 'context_color'): 'Bar'})
-        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(CONTEXT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_context_color3(self):
         config(p_overrides={('colorscheme', 'context_color'): 'magenta'})
-        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(CONTEXT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;35m')
 
     def test_context_color4(self):
         config(p_overrides={('colorscheme', 'context_color'): '392'})
-        color = get_ansi_color(CONTEXT_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(CONTEXT_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_metadata_color1(self):
         config(p_overrides={('colorscheme', 'metadata_color'): '128'})
-        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(METADATA_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;38;5;128m')
 
     def test_metadata_color2(self):
         config(p_overrides={('colorscheme', 'metadata_color'): 'Baz'})
-        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(METADATA_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_metadata_color3(self):
         config(p_overrides={('colorscheme', 'metadata_color'): 'light-red'})
-        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(METADATA_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, '\033[1;1;31m')
 
     def test_metadata_color4(self):
         config(p_overrides={('colorscheme', 'metadata_color'): '777'})
-        color = get_ansi_color(METADATA_COLOR, None, True, p_decoration='bold')
+        color = get_ansi_color(METADATA_COLOR, p_todo=None, p_decoration='bold')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_link_color1(self):
         config(p_overrides={('colorscheme', 'link_color'): '77'})
-        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
+        color = get_ansi_color(LINK_COLOR, p_todo=None,
+                               p_decoration='underline')
 
         self.assertEqual(color, '\033[4;38;5;77m')
 
     def test_link_color2(self):
         config(p_overrides={('colorscheme', 'link_color'): 'FooBar'})
-        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
+        color = get_ansi_color(LINK_COLOR, p_todo=None,
+                               p_decoration='underline')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
     def test_link_color3(self):
         config(p_overrides={('colorscheme', 'link_color'): 'red'})
-        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
+        color = get_ansi_color(LINK_COLOR, p_todo=None,
+                               p_decoration='underline')
 
         self.assertEqual(color, '\033[4;31m')
 
     def test_link_color4(self):
         config(p_overrides={('colorscheme', 'link_color'): '777'})
-        color = get_ansi_color(LINK_COLOR, None, True, p_decoration='underline')
+        color = get_ansi_color(LINK_COLOR, p_todo=None,
+                               p_decoration='underline')
 
         self.assertEqual(color, get_ansi_color(NEUTRAL_COLOR, None))
 
@@ -129,13 +133,13 @@ class ColorsTest(TopydoTest):
         todo_b = Todo('(B) Bar')
         todo_c = Todo('(C) FooBar')
 
-        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
-        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
-        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c)
 
-        self.assertEqual(color_a, '\033[0;38;5;1m')
-        self.assertEqual(color_b, '\033[0;38;5;2m')
-        self.assertEqual(color_c, '\033[0;38;5;3m')
+        self.assertEqual(color_a, '\033[0;31m')
+        self.assertEqual(color_b, '\033[0;32m')
+        self.assertEqual(color_c, '\033[0;33m')
 
     def test_priority_color2(self):
         config("test/data/ColorsTest2.conf")
@@ -143,9 +147,9 @@ class ColorsTest(TopydoTest):
         todo_b = Todo('(B) Bar')
         todo_c = Todo('(C) FooBar')
 
-        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
-        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
-        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c)
 
         self.assertEqual(color_a, '\033[0;35m')
         self.assertEqual(color_b, '\033[0;1;36m')
@@ -155,21 +159,21 @@ class ColorsTest(TopydoTest):
         config("test/data/ColorsTest3.conf")
         todo_a = Todo('(A) Foo')
         todo_b = Todo('(B) Bar')
-        todo_z = Todo('(C) FooBar')
-        todo_d = Todo('(C) Baz')
+        todo_z = Todo('(Z) FooBar')
+        todo_d = Todo('(D) Baz')
         todo_c = Todo('(C) FooBaz')
 
-        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
-        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
-        color_z = get_ansi_color(PRIORITY_COLOR, todo_z, True)
-        color_d = get_ansi_color(PRIORITY_COLOR, todo_d, True)
-        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b)
+        color_z = get_ansi_color(PRIORITY_COLOR, todo_z)
+        color_d = get_ansi_color(PRIORITY_COLOR, todo_d)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c)
 
         self.assertEqual(color_a, '\033[0;35m')
         self.assertEqual(color_b, '\033[0;1;36m')
-        self.assertEqual(color_z, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_z, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
         self.assertEqual(color_d, '\033[0;31m')
-        self.assertEqual(color_c, '\033[0;38;5;7m')
+        self.assertEqual(color_c, '\033[0;37m')
 
     def test_priority_color4(self):
         config("test/data/ColorsTest4.conf")
@@ -177,36 +181,36 @@ class ColorsTest(TopydoTest):
         todo_b = Todo('(B) Bar')
         todo_c = Todo('(C) FooBar')
 
-        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
-        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
-        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c)
 
-        self.assertEqual(color_a, get_ansi_color(NEUTRAL_COLOR))
-        self.assertEqual(color_b, get_ansi_color(NEUTRAL_COLOR))
-        self.assertEqual(color_c, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_a, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
+        self.assertEqual(color_b, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
+        self.assertEqual(color_c, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
 
     def test_empty_color_values(self):
         config("test/data/ColorsTest5.conf")
-        project_color = get_ansi_color(PROJECT_COLOR, None, True,
+        project_color = get_ansi_color(PROJECT_COLOR, p_todo=None,
                                        p_decoration='bold')
-        context_color = get_ansi_color(CONTEXT_COLOR, None, True,
+        context_color = get_ansi_color(CONTEXT_COLOR, p_todo=None,
                                        p_decoration='bold')
-        link_color = get_ansi_color(LINK_COLOR, None, True,
+        link_color = get_ansi_color(LINK_COLOR, p_todo=None,
                                     p_decoration='underline')
-        metadata_color = get_ansi_color(METADATA_COLOR, None, True,
+        metadata_color = get_ansi_color(METADATA_COLOR, p_todo=None,
                                         p_decoration='bold')
 
         todo_a = Todo('(A) Foo')
         todo_b = Todo('(B) Bar')
         todo_c = Todo('(C) FooBar')
 
-        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
-        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
-        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c)
 
-        self.assertEqual(color_a, get_ansi_color(NEUTRAL_COLOR))
-        self.assertEqual(color_b, get_ansi_color(NEUTRAL_COLOR))
-        self.assertEqual(color_c, get_ansi_color(NEUTRAL_COLOR))
+        self.assertEqual(color_a, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
+        self.assertEqual(color_b, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
+        self.assertEqual(color_c, get_ansi_color(NEUTRAL_COLOR, p_todo=None))
         self.assertEqual(project_color, '')
         self.assertEqual(context_color, '')
         self.assertEqual(link_color, '')
@@ -214,22 +218,22 @@ class ColorsTest(TopydoTest):
 
     def test_empty_colorscheme(self):
         config("test/data/config1")
-        project_color = get_ansi_color(PROJECT_COLOR, None, True,
+        project_color = get_ansi_color(PROJECT_COLOR, p_todo=None,
                                        p_decoration='bold')
-        context_color = get_ansi_color(CONTEXT_COLOR, None, True,
+        context_color = get_ansi_color(CONTEXT_COLOR, p_todo=None,
                                        p_decoration='bold')
-        link_color = get_ansi_color(LINK_COLOR, None, True,
+        link_color = get_ansi_color(LINK_COLOR, p_todo=None,
                                     p_decoration='underline')
-        metadata_color = get_ansi_color(METADATA_COLOR, None, True,
+        metadata_color = get_ansi_color(METADATA_COLOR, p_todo=None,
                                         p_decoration='bold')
 
         todo_a = Todo('(A) Foo')
         todo_b = Todo('(B) Bar')
         todo_c = Todo('(C) FooBar')
 
-        color_a = get_ansi_color(PRIORITY_COLOR, todo_a, True)
-        color_b = get_ansi_color(PRIORITY_COLOR, todo_b, True)
-        color_c = get_ansi_color(PRIORITY_COLOR, todo_c, True)
+        color_a = get_ansi_color(PRIORITY_COLOR, todo_a)
+        color_b = get_ansi_color(PRIORITY_COLOR, todo_b)
+        color_c = get_ansi_color(PRIORITY_COLOR, todo_c)
 
         self.assertEqual(color_a, '\033[0;36m')
         self.assertEqual(color_b, '\033[0;33m')

--- a/test/test_list_format.py
+++ b/test/test_list_format.py
@@ -679,7 +679,7 @@ C -
         self.assertEqual(self.output, result)
 
     @mock.patch('topydo.lib.ListFormat.get_terminal_size')
-    def test_list_format44(self, mock_terminal_size):
+    def test_list_format45(self, mock_terminal_size):
         """ Colorblocks should not affect truncating or right_alignment. """
         self.maxDiff = None
         mock_terminal_size.return_value = self.terminal_size(100, 25)

--- a/topydo/lib/Colors.py
+++ b/topydo/lib/Colors.py
@@ -56,15 +56,14 @@ def get_color(p_type, p_todo, p_256color=False):
         }
 
         try:
-            return color_names_dict[p_input]
-        except KeyError:
-            try:
+            if p_input in color_names_dict:
+                return color_names_dict[p_input]
+            elif not p_input:  # empty color config value
+                return None
+            else:
                 return int(p_input)
-            except ValueError:
-                if p_input:
-                    return -1
-                else:
-                    return p_input
+        except ValueError:
+            return -1
 
     def priority_color():
         priority_colors = config().priority_colors()
@@ -196,13 +195,13 @@ def get_ansi_color(p_type, p_todo, p_background=None, p_decoration='normal'):
     fg_color = get_color(p_type, p_todo)
     bg_color = get_color(p_background, p_todo) if p_background else -1
 
-    try:
-        if 256 > fg_color >= 0:
-            decoration = decoration_dict[p_decoration]
-        else:
-            decoration = '0'
-    except TypeError:
+    if fg_color is None:  # empty color config value
         return ''
+
+    if 256 > fg_color >= 0:
+        decoration = decoration_dict[p_decoration]
+    else:
+        decoration = '0'
 
     return '\033[{}{}{}m'.format(
         decoration,

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -250,13 +250,13 @@ class _Config:
                 try:
                     pri_colors_dict[pri] = int(color)
                 except ValueError:
-                    pri_colors_dict[pri] = color
+                    pri_colors_dict[pri] = color if color else -1
 
             return pri_colors_dict
 
         try:
             if pri_colors_str == '':
-                pri_colors_dict = {'A': '', 'B': '', 'C': ''}
+                pri_colors_dict = {'A': -1, 'B': -1, 'C': -1}
             else:
                 pri_colors_dict = _str_to_dict(pri_colors_str)
         except ValueError:
@@ -268,25 +268,25 @@ class _Config:
         try:
             return self.cp.getint('colorscheme', 'project_color')
         except ValueError:
-            return self.defaults['colorscheme']['project_color']
+            return self.cp.get('colorscheme', 'project_color')
 
     def context_color(self):
         try:
             return self.cp.getint('colorscheme', 'context_color')
         except ValueError:
-            return self.defaults['colorscheme']['context_color']
+            return self.cp.get('colorscheme', 'context_color')
 
     def metadata_color(self):
         try:
             return self.cp.getint('colorscheme', 'metadata_color')
         except ValueError:
-            return self.defaults['colorscheme']['metadata_color']
+            return self.cp.get('colorscheme', 'metadata_color')
 
     def link_color(self):
         try:
             return self.cp.getint('colorscheme', 'link_color')
         except ValueError:
-            return self.defaults['colorscheme']['link_color']
+            return self.cp.get('colorscheme', 'link_color')
 
     def auto_creation_date(self):
         try:

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -133,8 +133,8 @@ def color_block(p_todo, p_safe=True):
     # progress_color = get_color(PROGRESS_COLOR, p_todo, not p_safe0)
 
     return '{} {}'.format(
-        get_ansi_color(NEUTRAL_COLOR, p_todo, not p_safe, p_background=PROGRESS_COLOR),
-        get_ansi_color(PRIORITY_COLOR, p_todo, not p_safe)
+        get_ansi_color(NEUTRAL_COLOR, p_todo, p_background=PROGRESS_COLOR),
+        get_ansi_color(PRIORITY_COLOR, p_todo)
     )
 
 class ListFormatParser(object):


### PR DESCRIPTION
Seems like everything works now, but 2 nasty hacks are involved:

1. [Colors.py@199](https://github.com/mruwek/topydo/blob/a3651423b15c3e369e872334a345634e5fd828ea/topydo/lib/Colors.py#L199)
2. [Colors.py@61](https://github.com/mruwek/topydo/blob/a3651423b15c3e369e872334a345634e5fd828ea/topydo/lib/Colors.py#L61)

Ideas for cleaner solutions are welcome :)