### PR TITLE
Provides a smart way to determine the number 'top' lines

### DIFF
--- a/test/test_list_command.py
+++ b/test/test_list_command.py
@@ -17,6 +17,7 @@
 import codecs
 import re
 import os
+import sys
 import unittest
 from collections import namedtuple
 
@@ -346,7 +347,10 @@ class ListCommandTest(CommandTest):
         Test 'N' parameter with output longer than available terminal lines.
         """
         self.todolist = load_file_to_todolist("test/data/ListCommand_50_items.txt")
-        mock_terminal_size.return_value = self.terminal_size(80, 23)
+        if "win32" in sys.platform:
+            mock_terminal_size.return_value = self.terminal_size(80, 23)
+        else:
+            mock_terminal_size.return_value = self.terminal_size(80, 22)
 
         command = ListCommand(["-N"], self.todolist, self.out, self.error)
         command.execute()
@@ -360,7 +364,10 @@ class ListCommandTest(CommandTest):
         """Test basic 'N' parameter with nine line terminal."""
         # have 9 lines on the terminal will print 7 items and leave 2 lines
         # for the next prompt
-        mock_terminal_size.return_value = self.terminal_size(100, 9)
+        if "win32" in sys.platform:
+            mock_terminal_size.return_value = self.terminal_size(100, 9)
+        else:
+            mock_terminal_size.return_value = self.terminal_size(100, 8)
         self.todolist = load_file_to_todolist("test/data/ListCommand_50_items.txt")
 
         command = ListCommand(["-N"], self.todolist, self.out, self.error)
@@ -391,7 +398,10 @@ class ListCommandTest(CommandTest):
         Test 'N' parameter with multiline prompt.
         """
         self.todolist = load_file_to_todolist("test/data/ListCommand_50_items.txt")
-        mock_terminal_size.return_value = self.terminal_size(80, 23)
+        if "win32" in sys.platform:
+            mock_terminal_size.return_value = self.terminal_size(80, 23)
+        else:
+            mock_terminal_size.return_value = self.terminal_size(80, 22)
 
         command = ListCommand(["-N"], self.todolist, self.out, self.error)
         command.execute()

--- a/test/test_list_command.py
+++ b/test/test_list_command.py
@@ -340,7 +340,7 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (C) 2015-11-05 Foo @Context2 Not@Context +Project1 Not+Project\n|  4| (C) Drink beer @ home\n|  5| (C) 13 + 29 = 42\n|  2| (D) Bar @Context1 +Project2\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
     @mock.patch.dict(os.environ, {'PROMPT':'', 'PS1':''})
     def test_list44(self, mock_terminal_size):
         """
@@ -358,7 +358,7 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (A) item 1\n| 27| (A) item 27\n|  2| (B) item 2\n| 28| (B) item 28\n|  3| (C) item 3\n| 29| (C) item 29\n|  4| (D) item 4\n| 30| (D) item 30\n|  5| (E) item 5\n| 31| (E) item 31\n|  6| (F) item 6\n| 32| (F) item 32\n|  7| (G) item 7\n| 33| (G) item 33\n|  8| (H) item 8\n| 34| (H) item 34\n|  9| (I) item 9\n| 35| (I) item 35\n| 10| (J) item 10\n| 36| (J) item 36\n| 11| (K) item 11\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
     @mock.patch.dict(os.environ, {'PROMPT':'', 'PS1':''})
     def test_list45(self, mock_terminal_size):
         """Test basic 'N' parameter with nine line terminal."""
@@ -376,7 +376,7 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (A) item 1\n| 27| (A) item 27\n|  2| (B) item 2\n| 28| (B) item 28\n|  3| (C) item 3\n| 29| (C) item 29\n|  4| (D) item 4\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
     @mock.patch.dict(os.environ, {'PROMPT':'', 'PS1':''})
     def test_list46(self, mock_terminal_size):
         """Test basic 'N' parameter with zero height terminal."""
@@ -390,7 +390,7 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (A) item 1\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
     @mock.patch.dict(os.environ, {'PROMPT':'$E[1;34m%username%@%computername%$E[0m$S$E[1;32m$P$E[0m$_$E[1;37m--$E[0m$S',
                                   'PS1':'username@hostname\n--'})
     def test_list47(self, mock_terminal_size):

--- a/test/test_list_command.py
+++ b/test/test_list_command.py
@@ -16,6 +16,7 @@
 
 import codecs
 import re
+import os
 import unittest
 from collections import namedtuple
 
@@ -338,7 +339,8 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (C) 2015-11-05 Foo @Context2 Not@Context +Project1 Not+Project\n|  4| (C) Drink beer @ home\n|  5| (C) 13 + 29 = 42\n|  2| (D) Bar @Context1 +Project2\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
+    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch.dict(os.environ, {'PROMPT':'', 'PS1':''})
     def test_list44(self, mock_terminal_size):
         """
         Test 'N' parameter with output longer than available terminal lines.
@@ -352,7 +354,8 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (A) item 1\n| 27| (A) item 27\n|  2| (B) item 2\n| 28| (B) item 28\n|  3| (C) item 3\n| 29| (C) item 29\n|  4| (D) item 4\n| 30| (D) item 30\n|  5| (E) item 5\n| 31| (E) item 31\n|  6| (F) item 6\n| 32| (F) item 32\n|  7| (G) item 7\n| 33| (G) item 33\n|  8| (H) item 8\n| 34| (H) item 34\n|  9| (I) item 9\n| 35| (I) item 35\n| 10| (J) item 10\n| 36| (J) item 36\n| 11| (K) item 11\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
+    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch.dict(os.environ, {'PROMPT':'', 'PS1':''})
     def test_list45(self, mock_terminal_size):
         """Test basic 'N' parameter with nine line terminal."""
         # have 9 lines on the terminal will print 7 items and leave 2 lines
@@ -366,7 +369,8 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (A) item 1\n| 27| (A) item 27\n|  2| (B) item 2\n| 28| (B) item 28\n|  3| (C) item 3\n| 29| (C) item 29\n|  4| (D) item 4\n")
         self.assertEqual(self.errors, "")
 
-    @mock.patch('topydo.commands.ListCommand.get_terminal_size')
+    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch.dict(os.environ, {'PROMPT':'', 'PS1':''})
     def test_list46(self, mock_terminal_size):
         """Test basic 'N' parameter with zero height terminal."""
         # we still print at least 1 item
@@ -379,7 +383,23 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.output, "|  1| (A) item 1\n")
         self.assertEqual(self.errors, "")
 
-    def test_list47(self):
+    @mock.patch('topydo.lib.ListFormat.get_terminal_size')
+    @mock.patch.dict(os.environ, {'PROMPT':'$E[1;34m%username%@%computername%$E[0m$S$E[1;32m$P$E[0m$_$E[1;37m--$E[0m$S',
+                                  'PS1':'username@hostname\n--'})
+    def test_list47(self, mock_terminal_size):
+        """
+        Test 'N' parameter with multiline prompt.
+        """
+        self.todolist = load_file_to_todolist("test/data/ListCommand_50_items.txt")
+        mock_terminal_size.return_value = self.terminal_size(80, 23)
+
+        command = ListCommand(["-N"], self.todolist, self.out, self.error)
+        command.execute()
+
+        self.assertEqual(self.output, "|  1| (A) item 1\n| 27| (A) item 27\n|  2| (B) item 2\n| 28| (B) item 28\n|  3| (C) item 3\n| 29| (C) item 29\n|  4| (D) item 4\n| 30| (D) item 30\n|  5| (E) item 5\n| 31| (E) item 31\n|  6| (F) item 6\n| 32| (F) item 32\n|  7| (G) item 7\n| 33| (G) item 33\n|  8| (H) item 8\n| 34| (H) item 34\n|  9| (I) item 9\n| 35| (I) item 35\n| 10| (J) item 10\n| 36| (J) item 36\n")
+        self.assertEqual(self.errors, "")
+
+    def test_list48(self):
         command = ListCommand(["created:2015-11-05"], self.todolist, self.out, self.error)
         command.execute()
 

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -17,10 +17,10 @@
 from topydo.lib.Config import config
 from topydo.lib.ExpressionCommand import ExpressionCommand
 from topydo.lib.Filter import InstanceFilter
+from topydo.lib.ListFormat import _N_lines
 from topydo.lib.PrettyPrinter import pretty_printer_factory
 from topydo.lib.prettyprinters.Format import PrettyPrinterFormatFilter
 from topydo.lib.TodoListBase import InvalidTodoException
-from topydo.lib.Utils import get_terminal_size
 
 
 class ListCommand(ExpressionCommand):
@@ -73,7 +73,7 @@ class ListCommand(ExpressionCommand):
             elif opt == '-N':
                 # 2 lines are assumed to be taken up by printing the next prompt
                 # display at least one item
-                self.limit = max(get_terminal_size().lines - 2, 1)
+                self.limit = _N_lines()
             elif opt == '-n':
                 try:
                     self.limit = int(value)

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -14,13 +14,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
+import sys
+import os
+
 from topydo.lib.Config import config
 from topydo.lib.ExpressionCommand import ExpressionCommand
 from topydo.lib.Filter import InstanceFilter
-from topydo.lib.ListFormat import _N_lines
 from topydo.lib.PrettyPrinter import pretty_printer_factory
 from topydo.lib.prettyprinters.Format import PrettyPrinterFormatFilter
 from topydo.lib.TodoListBase import InvalidTodoException
+from topydo.lib.Utils import get_terminal_size
 
 
 class ListCommand(ExpressionCommand):
@@ -73,7 +77,7 @@ class ListCommand(ExpressionCommand):
             elif opt == '-N':
                 # 2 lines are assumed to be taken up by printing the next prompt
                 # display at least one item
-                self.limit = _N_lines()
+                self.limit = self._N_lines()
             elif opt == '-n':
                 try:
                     self.limit = int(value)
@@ -129,6 +133,36 @@ class ListCommand(ExpressionCommand):
             self.printer = pretty_printer_factory(self.todolist, filters)
 
         self.out(self.printer.print_list(self._view().todos))
+
+    def _N_lines(self):
+        ''' Determine how many lines to print, such that the number of items
+            displayed will fit on the terminal (i.e one 'screen-ful' of items)
+
+            This looks at the environmental prompt variable, and tries to determine
+            how many lines it takes up.
+
+            On Windows, it does this by looking for the '$_' sequence, which indicates
+            a new line, in the environmental variable PROMPT.
+
+            Otherwise, it looks for a newline ('\n') in the environmental variable
+            PS1.
+        '''  
+        lines_in_prompt = 1     # prompt is assumed to take up one line, even
+                                #   without any newlines in it
+        if "win32" in sys.platform:
+            lines_in_prompt += 1  # Windows will typically print a free line after
+                                  #   the program output
+            a = re.findall('\$_', os.getenv('PROMPT', ''))
+            lines_in_prompt += len(a)
+        else:
+            a = re.findall('\\n', os.getenv('PS1', ''))
+            lines_in_prompt += len(a)
+        n_lines = get_terminal_size().lines - lines_in_prompt
+
+        # print a minimum of one item
+        n_lines = max(n_lines, 1)
+
+        return n_lines
 
     def execute(self):
         if not super().execute():

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -17,7 +17,9 @@
 """ Utilities for formatting output with "list_format" option."""
 
 import arrow
+import os
 import re
+import sys
 
 from topydo.lib.Config import config
 from topydo.lib.Utils import get_terminal_size
@@ -279,3 +281,32 @@ class ListFormatParser(object):
             parsed_str = _right_align(parsed_str)
 
         return parsed_str.rstrip()
+
+def _N_lines():
+    ''' Determine how many lines to print, such that the number of items
+        displayed will fit on the terminal (i.e one 'screen-ful' of items)
+
+        This looks at the environmental prompt variable, and tries to determine
+        how many lines it takes up.
+
+        On Windows, it does this by looking for the '$_' sequence, which indicates
+        a new line, in the environmental variable PROMPT.
+
+        Otherwise, it looks for a newline ('\n') in the environmental variable
+        PS1.
+    '''  
+    lines_in_prompt = 2     # prompt is assumed to take up one line, even
+                            #   without any newlines in it, plus there is a free
+                            #   line printed out after the program output
+    if "win32" in sys.platform:
+        a = re.findall('\$_', os.getenv('PROMPT', ''))
+        lines_in_prompt += len(a)
+    else:
+        a = re.findall('\\n', os.getenv('PS1', ''))
+        lines_in_prompt += len(a)
+    n_lines = get_terminal_size().lines - lines_in_prompt
+
+    # print a minimum of one item
+    n_lines = max(n_lines, 1)
+
+    return n_lines

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -295,10 +295,11 @@ def _N_lines():
         Otherwise, it looks for a newline ('\n') in the environmental variable
         PS1.
     '''  
-    lines_in_prompt = 2     # prompt is assumed to take up one line, even
-                            #   without any newlines in it, plus there is a free
-                            #   line printed out after the program output
+    lines_in_prompt = 1     # prompt is assumed to take up one line, even
+                            #   without any newlines in it
     if "win32" in sys.platform:
+        lines_in_prompt += 1  # Windows will typically print a free line after
+                              #   the program output
         a = re.findall('\$_', os.getenv('PROMPT', ''))
         lines_in_prompt += len(a)
     else:

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -17,9 +17,7 @@
 """ Utilities for formatting output with "list_format" option."""
 
 import arrow
-import os
 import re
-import sys
 
 from topydo.lib.Config import config
 from topydo.lib.Utils import get_terminal_size
@@ -281,33 +279,3 @@ class ListFormatParser(object):
             parsed_str = _right_align(parsed_str)
 
         return parsed_str.rstrip()
-
-def _N_lines():
-    ''' Determine how many lines to print, such that the number of items
-        displayed will fit on the terminal (i.e one 'screen-ful' of items)
-
-        This looks at the environmental prompt variable, and tries to determine
-        how many lines it takes up.
-
-        On Windows, it does this by looking for the '$_' sequence, which indicates
-        a new line, in the environmental variable PROMPT.
-
-        Otherwise, it looks for a newline ('\n') in the environmental variable
-        PS1.
-    '''  
-    lines_in_prompt = 1     # prompt is assumed to take up one line, even
-                            #   without any newlines in it
-    if "win32" in sys.platform:
-        lines_in_prompt += 1  # Windows will typically print a free line after
-                              #   the program output
-        a = re.findall('\$_', os.getenv('PROMPT', ''))
-        lines_in_prompt += len(a)
-    else:
-        a = re.findall('\\n', os.getenv('PS1', ''))
-        lines_in_prompt += len(a)
-    n_lines = get_terminal_size().lines - lines_in_prompt
-
-    # print a minimum of one item
-    n_lines = max(n_lines, 1)
-
-    return n_lines


### PR DESCRIPTION
Looks at the prompt or PS1 environmental variables to determine the number of
newlines contained in them.

I've tested in on my end in Windows, and it works as expected. I don't have Linux or Mac box, so I haven't been able to test it there.

Because of the way it works (by counting newlines), it won't work exactly right if the prompt goes over the line end without a line break (i.e. for a really long path) or if there are conditional linebreaks in the PS1 variable.

Tests have been added and updated as well.

Fixes #102.