### PR TITLE
Use special color-palette entry for 'marked' items

### DIFF
--- a/topydo/ui/Main.py
+++ b/topydo/ui/Main.py
@@ -179,6 +179,7 @@ class UIApplication(CLIApplicationBase):
             ('link', '', '', '', link_color, ''),
             ('link_focus', '', 'light gray', '', link_color, None),
             ('default_focus', 'black', 'light gray'),
+            ('marked', '', 'light blue'),
         ]
 
         for C in ascii_uppercase:

--- a/topydo/ui/TodoWidget.py
+++ b/topydo/ui/TodoWidget.py
@@ -135,7 +135,14 @@ class TodoWidget(urwid.WidgetWrap):
         return True
 
     def mark(self):
-        self.widget.set_attr_map({None: _markup(self.todo, True)})
+        attr_map = {
+            None:       'marked',
+            'link':     'marked',
+            'context':  'marked',
+            'project':  'marked',
+            'metadata': 'marked',
+        }
+        self.widget.set_attr_map(attr_map)
 
     def unmark(self):
-        self.widget.set_attr_map({None: _markup(self.todo, False)})
+        self.widget.set_attr_map(_markup(self.todo, False))


### PR DESCRIPTION
This improves readability. Marked items look now differently from the focused one.

It also fixes one accidental bug (introduced with #114) where marking/un-marking todo item would crash the whole app (cfr [line 141](https://github.com/bram85/topydo/commit/f9e1606d28b39f16afeb3c2bd88466a7807e9453#diff-baa20e346ffde5043dbddab87fb41402L141) in TodoWidget.py).

### Before:

![before](https://cloud.githubusercontent.com/assets/500710/14425259/2e031f00-ffe6-11e5-831d-550b880c9750.png)

### After:

![after](https://cloud.githubusercontent.com/assets/500710/14425267/3877cde6-ffe6-11e5-9691-5f57f4381af0.png)
