### PR TITLE
Provide adequate "mono" palette for column ui

### DIFF
--- a/topydo/ui/Main.py
+++ b/topydo/ui/Main.py
@@ -149,7 +149,12 @@ class UIApplication(CLIApplicationBase):
         self._blur_commandline()
 
         self._screen = urwid.raw_display.Screen()
-        self._screen.register_palette(self._create_color_palette())
+
+        if config().colors():
+            self._screen.register_palette(self._create_color_palette())
+        else:
+            self._screen.register_palette(self._create_mono_palette())
+
         self._screen.set_terminal_properties(256)
 
         self.mainloop = urwid.MainLoop(
@@ -163,10 +168,6 @@ class UIApplication(CLIApplicationBase):
         self._set_alarm_for_next_midnight_update()
 
     def _create_color_palette(self):
-        if not config().colors():
-            # return an empty palette:
-            return []
-
         project_color = to_urwid_color(config().project_color())
         context_color = to_urwid_color(config().context_color())
         metadata_color = to_urwid_color(config().metadata_color())
@@ -197,6 +198,23 @@ class UIApplication(CLIApplicationBase):
             palette.append((
                 'pri_' + C + '_focus', '', 'light gray', '', pri_color_focus, None
             ))
+
+        return palette
+
+    def _create_mono_palette(self):
+        palette = [
+            (PaletteItem.DEFAULT_FOCUS, 'black', 'light gray'),
+            (PaletteItem.PROJECT_FOCUS, PaletteItem.DEFAULT_FOCUS),
+            (PaletteItem.CONTEXT_FOCUS, PaletteItem.DEFAULT_FOCUS),
+            (PaletteItem.METADATA_FOCUS, PaletteItem.DEFAULT_FOCUS),
+            (PaletteItem.LINK_FOCUS, PaletteItem.DEFAULT_FOCUS),
+            (PaletteItem.MARKED, 'default,underline,bold', 'default'),
+        ]
+
+        for C in ascii_uppercase:
+            palette.append(
+                ('pri_' + C + '_focus', PaletteItem.DEFAULT_FOCUS)
+            )
 
         return palette
 


### PR DESCRIPTION
Focused items are now properly highlighted when colors are set to 0 and marked items are made bold and underlined.

### Before
![scrn-before](https://cloud.githubusercontent.com/assets/500710/14643486/dad3db34-064e-11e6-85b9-9eec701791b0.png)

### After
![scrn-after](https://cloud.githubusercontent.com/assets/500710/14643488/dcc027b8-064e-11e6-90b6-da60e5fc00e8.png)

