### PR TITLE
Properly print progress color-blocks in ConsoleWidget

### DIFF
--- a/topydo/lib/Color.py
+++ b/topydo/lib/Color.py
@@ -45,10 +45,11 @@ class Color:
         'white': 15,
     }
 
-    def __init__(self, p_value=None):
+    def __init__(self, p_value=None, p_background=False):
         """ p_value is user input, be it a word color or an xterm code """
         self._value = None
         self.color = p_value
+        self.background = p_background
 
     @property
     def color(self):
@@ -85,7 +86,7 @@ class Color:
         """
         return self._value is not None
 
-    def as_ansi(self, p_decoration='normal', p_background=False):
+    def as_ansi(self, p_decoration='normal'):
         if not self.is_valid():
             return ''
         elif self.is_neutral():
@@ -103,7 +104,7 @@ class Color:
         }
         decoration = decoration_dict[p_decoration]
 
-        base = 40 if p_background else 30
+        base = 40 if self.background else 30
         if is_high_color:
             color = '1;{}'.format(base + self._value - 8)
         elif is_256:

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -20,7 +20,6 @@ import arrow
 import re
 
 from topydo.lib.Config import config
-from topydo.lib.ProgressColor import progress_color
 from topydo.lib.Utils import get_terminal_size, escape_ansi
 
 MAIN_PATTERN = (r'^({{(?P<before>.+?)}})?'
@@ -129,11 +128,6 @@ def _right_align(p_str):
 
     return p_str
 
-def color_block(p_todo):
-    return '{} {}'.format(
-        progress_color(p_todo).as_ansi(),
-        config().priority_color(p_todo.priority()).as_ansi(),
-    )
 
 class ListFormatParser(object):
     """ Parser of format string. """
@@ -204,7 +198,9 @@ class ListFormatParser(object):
             # relative completion date
             'X': lambda t: 'x ' + humanize_date(t.completion_date()) if t.is_completed() else '',
 
-            'z': lambda t: color_block(t) if config().colors() else ' ',
+            # progress color-block: use non printable bell char as a placeholder
+            # for coloring filter
+            'z': lambda t: '\a' if config().colors() else ' ',
         }
         self.format_list = self._preprocess_format()
 

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -131,7 +131,7 @@ def _right_align(p_str):
 
 def color_block(p_todo):
     return '{} {}'.format(
-        progress_color(p_todo).as_ansi(p_background=True),
+        progress_color(p_todo).as_ansi(),
         config().priority_color(p_todo.priority()).as_ansi(),
     )
 

--- a/topydo/lib/ProgressColor.py
+++ b/topydo/lib/ProgressColor.py
@@ -84,9 +84,9 @@ def progress_color(p_todo):
     # TODO: remove linear scale to exponential scale
     if progress > 1:
         # overdue, return the last color
-        return Color(color_range[-1])
+        return Color(color_range[-1], True)
     else:
         # not overdue, calculate position over color range excl. due date
         # color
         pos = round(progress * (len(color_range) - 2))
-        return Color(color_range[pos])
+        return Color(color_range[pos], True)

--- a/topydo/lib/prettyprinters/Colors.py
+++ b/topydo/lib/prettyprinters/Colors.py
@@ -21,6 +21,7 @@ import re
 from topydo.lib.Color import AbstractColor
 from topydo.lib.Config import config
 from topydo.lib.PrettyPrinterFilter import PrettyPrinterFilter
+from topydo.lib.ProgressColor import progress_color
 from topydo.lib.TopydoString import TopydoString
 
 
@@ -37,12 +38,14 @@ class PrettyPrinterColorFilter(PrettyPrinterFilter):
             p_todo_str = TopydoString(p_todo_str, p_todo)
 
             priority_color = config().priority_color(p_todo.priority())
+            todo_prog_color = progress_color(p_todo)
 
             colors = [
                 (r'\B@(\S*\w)', AbstractColor.CONTEXT),
                 (r'\B\+(\S*\w)', AbstractColor.PROJECT),
                 (r'\b\S+:[^/\s]\S*\b', AbstractColor.META),
                 (r'(^|\s)(\w+:){1}(//\S+)', AbstractColor.LINK),
+                (r'\a+', todo_prog_color),
             ]
 
             # color by priority
@@ -54,6 +57,8 @@ class PrettyPrinterColorFilter(PrettyPrinterFilter):
                     p_todo_str.set_color(match.end(), priority_color)
 
             p_todo_str.append('', AbstractColor.NEUTRAL)
+            # convert non-printable progress bells to spaces
+            p_todo_str.data = re.sub(r'\a', ' ', p_todo_str.data)
 
         return p_todo_str
 

--- a/topydo/lib/prettyprinters/Colors.py
+++ b/topydo/lib/prettyprinters/Colors.py
@@ -45,15 +45,15 @@ class PrettyPrinterColorFilter(PrettyPrinterFilter):
                 (r'(^|\s)(\w+:){1}(//\S+)', AbstractColor.LINK),
             ]
 
+            # color by priority
+            p_todo_str.set_color(0, priority_color)
+
             for pattern, color in colors:
                 for match in re.finditer(pattern, p_todo_str.data):
                     p_todo_str.set_color(match.start(), color)
                     p_todo_str.set_color(match.end(), priority_color)
 
             p_todo_str.append('', AbstractColor.NEUTRAL)
-
-            # color by priority
-            p_todo_str.set_color(0, priority_color)
 
         return p_todo_str
 

--- a/topydo/ui/ConsoleWidget.py
+++ b/topydo/ui/ConsoleWidget.py
@@ -16,10 +16,10 @@
 
 import urwid
 
-from topydo.lib.Color import AbstractColor
+from topydo.lib.Color import AbstractColor, Color
 from topydo.lib.Todo import Todo
 from topydo.lib.TopydoString import TopydoString
-from topydo.ui.Utils import PaletteItem
+from topydo.ui.Utils import PaletteItem, to_urwid_color
 
 PALETTE_LOOKUP = {
     # omitting AbstractColor.NEUTRAL on purpose, so a text without any
@@ -55,6 +55,10 @@ def topydostringToMarkup(p_string):
 
         if color in PALETTE_LOOKUP:
             markup.append((PALETTE_LOOKUP[color], text))
+        # print progress color-block
+        elif isinstance(color, Color) and color.background:
+            progress = urwid.AttrSpec('', to_urwid_color(color), 256)
+            markup.append((progress, text))
         else:
             # a plain text without any attribute set (including
             # AbstractColor.NEUTRAL)


### PR DESCRIPTION
2 big changes to the coloring codebase:

1. `topydo.lib.Color` instance is now predetermined to be either foreground or background
2. Progress color is now calculated during `PrettyPrinterColorFilter.filter()` call.

Also fixed one bug that prevented showing colors of link/metadata/project/context when they were located at the start of the output string (e. g. `ls -F %s`)