### PR TITLE
Don't crash on shlex.split in column UI

### DIFF
--- a/topydo/cli/Prompt.py
+++ b/topydo/cli/Prompt.py
@@ -101,6 +101,7 @@ class PromptApplication(CLIApplicationBase):
                 continue
             except ValueError as verr:
                 error('Error: ' + str(verr))
+                continue
 
             mtime_after = _todotxt_mtime()
 

--- a/topydo/ui/Main.py
+++ b/topydo/ui/Main.py
@@ -245,7 +245,12 @@ class UIApplication(CLIApplicationBase):
                 p_todo_id = ' '.join(self.marked_todos)
             p_command = p_command.format(p_todo_id)
 
-        p_command = shlex.split(p_command)
+        try:
+            p_command = shlex.split(p_command)
+        except ValueError as verr:
+            self._print_to_console('Error: ' + str(verr))
+            return
+
         try:
             (subcommand, args) = get_subcommand(p_command)
         except ConfigError as cerr:


### PR DESCRIPTION
Also don't try to do anything after such error occurs so we don't trigger another crash if default_command is assinged to some alias.

Hopefully finaly fixes #107