### PR TITLE
Relative dates and dependencies in append cmd

### DIFF
--- a/test/test_append_command.py
+++ b/test/test_append_command.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from datetime import date
 
 from test.command_testcase import CommandTest
 from topydo.commands.AppendCommand import AppendCommand
@@ -26,6 +27,7 @@ class AppendCommandTest(CommandTest):
         super().setUp()
         self.todolist = TodoList([])
         self.todolist.add("Foo")
+        self.today = date.today().isoformat()
 
     def test_append1(self):
         command = AppendCommand([1, "Bar"], self.todolist, self.out,
@@ -78,6 +80,27 @@ class AppendCommandTest(CommandTest):
 
         self.assertEqual(self.output, "")
         self.assertEqual(self.errors, command.usage() + "\n")
+
+    def test_append8(self):
+        command = AppendCommand([1, "due:today t:today"], self.todolist,
+                                self.out, self.error)
+        command.execute()
+
+        self.assertEqual(self.output,
+                         "|  1| Foo due:%s t:%s\n" % (self.today, self.today))
+        self.assertEqual(self.errors, "")
+
+    def test_append9(self):
+        self.todolist.add("Qux due:2015-12-21 t:2015-12-21 before:1")
+        self.todolist.add("Baz")
+        command = AppendCommand([2, "due:today t:today before:3"], self.todolist,
+                                self.out, self.error)
+        command.execute()
+
+        self.assertEqual(
+                self.output,
+                "|  2| Qux due:%s t:%s p:1 p:2\n" % (self.today, self.today))
+        self.assertEqual(self.errors, "")
 
     def test_help(self):
         command = AppendCommand(["help"], self.todolist, self.out, self.error)

--- a/topydo/commands/AppendCommand.py
+++ b/topydo/commands/AppendCommand.py
@@ -14,12 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from topydo.lib.Command import Command, InvalidCommandArgument
+from topydo.lib.Config import config
+from topydo.lib.Command import InvalidCommandArgument
+from topydo.lib.WriteCommand import WriteCommand
 from topydo.lib.prettyprinters.Numbers import PrettyPrinterNumbers
 from topydo.lib.TodoListBase import InvalidTodoException
+from topydo.lib.TodoParser import parse_line
 
-
-class AppendCommand(Command):
+class AppendCommand(WriteCommand):
     def __init__(self, p_args, p_todolist, #pragma: no branch
                  p_out=lambda a: None,
                  p_err=lambda a: None,
@@ -37,7 +39,13 @@ class AppendCommand(Command):
 
             if text:
                 todo = self.todolist.todo(number)
+                new_text_parsed = parse_line(text)
+                new_tags = new_text_parsed['tags']
+                for tag in (config().tag_start(), config().tag_due()):
+                    if tag in new_tags:
+                        todo.remove_tag(tag)
                 self.todolist.append(todo, text)
+                self.postprocess_input_todo(todo)
 
                 self.printer.add_filter(PrettyPrinterNumbers(self.todolist))
                 self.out(self.printer.print_todo(todo))

--- a/topydo/lib/WriteCommand.py
+++ b/topydo/lib/WriteCommand.py
@@ -1,0 +1,77 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from topydo.lib.Command import Command
+from topydo.lib.Config import config
+from topydo.lib.RelativeDate import relative_date_to_date
+from topydo.lib.TodoListBase import InvalidTodoException
+
+
+class WriteCommand(Command):
+
+    def postprocess_input_todo(self, p_todo):
+        """
+        Post-processes a parsed todo when adding it to the list.
+
+        * It converts relative dates to absolute ones.
+        * Automatically inserts a creation date if not present.
+        * Handles more user-friendly dependencies with before:, partof: and
+        after: tags
+        """
+        def convert_date(p_tag):
+            value = p_todo.tag_value(p_tag)
+
+            if value:
+                dateobj = relative_date_to_date(value)
+                if dateobj:
+                    p_todo.set_tag(p_tag, dateobj.isoformat())
+
+        def add_dependencies(p_tag):
+            for value in p_todo.tag_values(p_tag):
+                try:
+                    dep = self.todolist.todo(value)
+
+                    if p_tag == 'after':
+                        self.todolist.add_dependency(p_todo, dep)
+                    elif p_tag == 'before' or p_tag == 'partof':
+                        self.todolist.add_dependency(dep, p_todo)
+                    elif p_tag.startswith('parent'):
+                        for parent in self.todolist.parents(dep):
+                            self.todolist.add_dependency(parent, p_todo)
+                    elif p_tag.startswith('child'):
+                        for child in self.todolist.children(dep):
+                            self.todolist.add_dependency(p_todo, child)
+                except InvalidTodoException:
+                    pass
+
+                p_todo.remove_tag(p_tag, value)
+
+        convert_date(config().tag_start())
+        convert_date(config().tag_due())
+
+        keywords = [
+            'after',
+            'before',
+            'child-of',
+            'childof',
+            'children-of',
+            'childrenof',
+            'parent-of',
+            'parentof',
+            'parents-of',
+            'parentsof',
+            'partof',
+        ]
+
+        for keyword in keywords:
+            add_dependencies(keyword)


### PR DESCRIPTION
This commit adds support for relative dates and
dependencies in the append command. Relative dates
in due and start dates will be automatically converted
and dependenices will be recomputed.

When appending due/start dates, if the command already
has due or start dates, it will be replaced.

Change-Id: Ifc2e94e5c7483ea36ccc7b06585e3ca960bc29b5