### PR TITLE
Allow `--version` as an alias for `-v`

### DIFF
--- a/topydo/ui/CLIApplicationBase.py
+++ b/topydo/ui/CLIApplicationBase.py
@@ -26,6 +26,7 @@ from topydo.lib.Color import AbstractColor, Color
 from topydo.lib.TopydoString import TopydoString
 
 MAIN_OPTS = "ac:C:d:ht:v"
+MAIN_LONG_OPTS = ('version')
 READ_ONLY_COMMANDS = ('List', 'ListContext', 'ListProject')
 
 
@@ -171,7 +172,7 @@ class CLIApplicationBase(object):
         args = sys.argv[1:]
 
         try:
-            opts, args = getopt.getopt(args, MAIN_OPTS)
+            opts, args = getopt.getopt(args, MAIN_OPTS, MAIN_LONG_OPTS)
         except getopt.GetoptError as e:
             error(str(e))
             sys.exit(1)
@@ -191,7 +192,7 @@ class CLIApplicationBase(object):
                 overrides[('topydo', 'filename')] = value
             elif opt == "-d":
                 overrides[('topydo', 'archive_filename')] = value
-            elif opt == "-v":
+            elif opt in ("-v", "--version"):
                 version()
             else:
                 self._usage()

--- a/topydo/ui/UILoader.py
+++ b/topydo/ui/UILoader.py
@@ -20,7 +20,7 @@ import getopt
 import sys
 
 from topydo.ui.cli.CLI import CLIApplication
-from topydo.ui.CLIApplicationBase import MAIN_OPTS, error
+from topydo.ui.CLIApplicationBase import MAIN_OPTS, MAIN_LONG_OPTS, error
 
 # enable color on windows CMD
 if "win32" in sys.platform:
@@ -34,7 +34,7 @@ def main():
         args = sys.argv[1:]
 
         try:
-            _, args = getopt.getopt(args, MAIN_OPTS)
+            _, args = getopt.getopt(args, MAIN_OPTS, MAIN_LONG_OPTS)
         except getopt.GetoptError as e:
             error(str(e))
             sys.exit(1)


### PR DESCRIPTION
Add a long version option.

I keep trying to run `topydo --version`, so I figured I'd make it work!