### PR TITLE
Fix saving backups when archiving is turned off

### DIFF
--- a/test/test_revert_command.py
+++ b/test/test_revert_command.py
@@ -284,6 +284,20 @@ class RevertCommandTest(CommandTest):
         self.assertEqual(result, [])
         self.assertEqual(self.errors, "")
 
+    def test_revert07(self):
+        """ Test backup when no archive file is set """
+        backup = ChangeSet(self.todolist, None, ['add One'])
+        backup.timestamp = '1'
+        command1 = AddCommand(["One"], self.todolist, self.out, self.error, None)
+        command1.execute()
+        backup.save(self.todolist)
+
+        changesets = list(backup.backup_dict.keys())
+        changesets.remove('index')
+
+        self.assertEqual(len(changesets), 1)
+        self.assertEqual(self.errors, "")
+
     def test_backup_config01(self):
         config(p_overrides={('topydo', 'backup_count'): '1'})
 

--- a/topydo/lib/ChangeSet.py
+++ b/topydo/lib/ChangeSet.py
@@ -99,7 +99,10 @@ class ChangeSet(object):
 
         current_hash = hash_todolist(p_todolist)
         list_todo = (self.todolist.print_todos()+'\n').splitlines(True)
-        list_archive = (self.archive.print_todos()+'\n').splitlines(True)
+        try:
+            list_archive = (self.archive.print_todos()+'\n').splitlines(True)
+        except AttributeError:
+            list_archive = []
 
         self.backup_dict[self.timestamp] = (list_todo, list_archive,  self.call)
 

--- a/topydo/ui/CLIApplicationBase.py
+++ b/topydo/ui/CLIApplicationBase.py
@@ -150,6 +150,17 @@ from topydo.lib import TodoListBase
 from topydo.lib.Utils import escape_ansi
 
 
+def _retrieve_archive():
+    """
+    Returns a tuple with archive content: the first element is a TodoListBase
+    and the second element is a TodoFile.
+    """
+    archive_file = TodoFile.TodoFile(config().archive())
+    archive = TodoListBase.TodoListBase(archive_file.read())
+
+    return (archive, archive_file)
+
+
 class CLIApplicationBase(object):
     """
     Base class for a Command Line Interfaces (CLI) for topydo. Examples are the
@@ -211,8 +222,7 @@ class CLIApplicationBase(object):
         This means that all completed tasks are moved to the archive file
         (defaults to done.txt).
         """
-        archive_file = TodoFile.TodoFile(config().archive())
-        archive = TodoListBase.TodoListBase(archive_file.read())
+        archive, archive_file = _retrieve_archive()
 
         if self.backup:
             self.backup.add_archive(archive)
@@ -275,6 +285,9 @@ class CLIApplicationBase(object):
             # (i.e. explicitly left empty in the configuration
             if self.do_archive and config().archive():
                 self._archive()
+            elif config().archive() and self.backup:
+                archive = _retrieve_archive()[0]
+                self.backup.add_archive(archive)
 
             if config().keep_sorted():
                 from topydo.commands.SortCommand import SortCommand


### PR DESCRIPTION
Use empty list if user left `archive_file` option empty.

This fixes #132