### PR TITLE
Properly unmark items when resetting state

### DIFF
--- a/topydo/ui/columns/Main.py
+++ b/topydo/ui/columns/Main.py
@@ -301,6 +301,8 @@ class UIApplication(CLIApplicationBase):
                               self._output if verbosity else lambda _: None)
 
     def _reset_state(self):
+        for widget in TodoWidget.cache.values():
+            widget.unmark()
         self.marked_todos = []
         self._update_all_columns()
 


### PR DESCRIPTION
After introducing cache for TodoWidget objects, widgets highlighted with
'mark' action were not unmarked after 'reset' action and they reappeared
highlighted ("marked") after reverting `do` or `delete` commands.