### PR TITLE
Fix importance being wrong when due date is a distant monday.

### DIFF
--- a/test/test_importance.py
+++ b/test/test_importance.py
@@ -56,5 +56,39 @@ class ImportanceTest(TopydoTest):
         todo = Todo("(C) Foo " + config().tag_due() + ":" + "2015-11-09")
         self.assertEqual(importance(todo), 6)
 
+
+@freeze_time("2016, 10, 21")
+class ImportanceWeekendFridayTest(TopydoTest):
+    def test_importance_ignore_weekends_due_not_next_monday(self):
+        # Today is friday
+        # due on a monday, but over a month away.
+        # So 2 + 0 (no priority) + 0 (no star) + 0 (due > 14 days)
+        config(p_overrides={('sort', 'ignore_weekends'): '1'})
+        todo = Todo("Foo " + config().tag_due() + ":" + "2016-11-28")
+        self.assertEqual(importance(todo), 2)
+
+
+@freeze_time("2016, 10, 22")
+class ImportanceWeekendSaturdayTest(TopydoTest):
+    def test_importance_ignore_weekends_due_not_next_monday(self):
+        # Today is saturday
+        # due on a monday, but over a month away.
+        # So 2 + 0 (no priority) + 0 (no star) + 0 (due > 14 days)
+        config(p_overrides={('sort', 'ignore_weekends'): '1'})
+        todo = Todo("Foo " + config().tag_due() + ":" + "2016-11-28")
+        self.assertEqual(importance(todo), 2)
+
+
+@freeze_time("2016, 10, 23")
+class ImportanceWeekendSundayTest(TopydoTest):
+    def test_importance_ignore_weekends_due_not_next_monday(self):
+        # Today is sunday
+        # due on a monday, but over a month away.
+        # So 2 + 0 (no priority) + 0 (no star) + 0 (due > 14 days)
+        config(p_overrides={('sort', 'ignore_weekends'): '1'})
+        todo = Todo("Foo " + config().tag_due() + ":" + "2016-11-28")
+        self.assertEqual(importance(todo), 2)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/topydo/lib/Importance.py
+++ b/topydo/lib/Importance.py
@@ -31,12 +31,14 @@ IMPORTANCE_VALUE = {'A': 3, 'B': 2, 'C': 1}
 
 
 def is_due_next_monday(p_todo):
-    """ Returns True when the given task is due next Monday. """
+    """ Returns True when today is Friday (or the weekend) and the given task
+    is due next Monday.
+    """
     today = date.today()
     due = p_todo.due_date()
 
     return due and due.weekday() == 0 and today.weekday() >= 4 and \
-        p_todo.days_till_due()
+        p_todo.days_till_due() <= 3
 
 
 def importance(p_todo, p_ignore_weekend=config().ignore_weekends()):


### PR DESCRIPTION
I discovered a problem today with how importance is calculated (eg, for sorting). Under the following conditions, a task's importance is one higher than it should be:

* I have mostly the default settings (`ignore_weekends` is 1)
* Today is 2016-10-22 (a saturday)
* I have a task due on 2016-11-28 (a monday)

The task shows up with other tasks with an importance of 3 instead of an importance of 2 (based on debugging).

Anyways, this PR tries to address the bug by addressing what looks like an oversight when determining whether to add 1 to the importance if the task is due on Monday.