### PR TITLE
configurable focus and marked background colors

### DIFF
--- a/test/data/ColorsTest5.conf
+++ b/test/data/ColorsTest5.conf
@@ -4,3 +4,5 @@ project_color =
 context_color =
 link_color =
 metadata_color =
+focus_background_color =
+marked_background_color =

--- a/topydo.conf
+++ b/topydo.conf
@@ -50,6 +50,8 @@ append_parent_contexts      = 0
 ; context_color = magenta
 ; metadata_color = green
 ; link_color = light-cyan
+; focus_background_color': gray,
+; marked_background_color': blue
 
 [aliases]
 ;showall = ls -x

--- a/topydo.conf
+++ b/topydo.conf
@@ -50,8 +50,8 @@ append_parent_contexts      = 0
 ; context_color = magenta
 ; metadata_color = green
 ; link_color = light-cyan
-; focus_background_color': gray,
-; marked_background_color': blue
+; focus_background_color = gray
+; marked_background_color = blue
 
 [aliases]
 ;showall = ls -x

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -103,15 +103,15 @@ class _Config:
             'colorscheme': {
                 'project_color': 'red',
                 'context_color': 'magenta',
-                'context_focus_background_color': 'light gray',
                 'metadata_color': 'green',
                 'link_color': 'cyan',
                 'priority_colors': 'A:cyan,B:yellow,C:blue',
-                'default_focus_background_color': '',
-                'project_focus_background_color': '',
-                'link_focus_background_color': '',
-                'metadata_focus_background_color': '',
-                'marked_background_color': ''
+                'context_focus_background_color': 'light gray',
+                'default_focus_background_color': 'light gray',
+                'project_focus_background_color': 'light gray',
+                'link_focus_background_color': 'light gray',
+                'metadata_focus_background_color': 'light gray',
+                'marked_background_color': 'light blue'
             },
 
             'aliases': {

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -103,9 +103,14 @@ class _Config:
             'colorscheme': {
                 'project_color': 'red',
                 'context_color': 'magenta',
+                'context_focus_background_color': 'light gray',
                 'metadata_color': 'green',
                 'link_color': 'cyan',
                 'priority_colors': 'A:cyan,B:yellow,C:blue',
+                'default_focus_background_color': '',
+                'project_focus_background_color': '',
+                'link_focus_background_color': '',
+                'metadata_focus_background_color': '',
             },
 
             'aliases': {
@@ -355,6 +360,12 @@ class _Config:
         except ValueError:
             return Color(self.cp.get('colorscheme', 'context_color'))
 
+    def context_focus_background_color(self):
+        try:
+            return Color(self.cp.getint('colorscheme', 'context_focus_background_color'))
+        except ValueError:
+            return Color(self.cp.get('colorscheme', 'context_focus_background_color'))
+
     def metadata_color(self):
         try:
             return Color(self.cp.getint('colorscheme', 'metadata_color'))
@@ -366,6 +377,30 @@ class _Config:
             return Color(self.cp.getint('colorscheme', 'link_color'))
         except ValueError:
             return Color(self.cp.get('colorscheme', 'link_color'))
+
+    def default_focus_background_color(self):
+        try:
+            return Color(self.cp.getint('colorscheme', 'default_focus_background_color'))
+        except ValueError:
+            return Color(self.cp.get('colorscheme', 'default_focus_background_color'))
+
+    def project_focus_background_color(self):
+        try:
+            return Color(self.cp.getint('colorscheme', 'project_focus_background_color'))
+        except ValueError:
+            return Color(self.cp.get('colorscheme', 'project_focus_background_color'))
+
+    def link_focus_background_color(self):
+        try:
+            return Color(self.cp.getint('colorscheme', 'link_focus_background_color'))
+        except ValueError:
+            return Color(self.cp.get('colorscheme', 'link_focus_background_color'))
+
+    def metadata_focus_background_color(self):
+        try:
+            return Color(self.cp.getint('colorscheme', 'metadata_focus_background_color'))
+        except ValueError:
+            return Color(self.cp.get('colorscheme', 'metadata_focus_background_color'))
 
     def auto_creation_date(self):
         try:

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -111,6 +111,7 @@ class _Config:
                 'project_focus_background_color': '',
                 'link_focus_background_color': '',
                 'metadata_focus_background_color': '',
+                'marked_background_color': ''
             },
 
             'aliases': {
@@ -401,6 +402,12 @@ class _Config:
             return Color(self.cp.getint('colorscheme', 'metadata_focus_background_color'))
         except ValueError:
             return Color(self.cp.get('colorscheme', 'metadata_focus_background_color'))
+
+    def marked_background_color(self):
+        try:
+            return Color(self.cp.getint('colorscheme', 'marked_background_color'))
+        except ValueError:
+            return Color(self.cp.get('colorscheme', 'marked_background_color'))
 
     def auto_creation_date(self):
         try:

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -106,12 +106,8 @@ class _Config:
                 'metadata_color': 'green',
                 'link_color': 'cyan',
                 'priority_colors': 'A:cyan,B:yellow,C:blue',
-                'context_focus_background_color': 'light gray',
-                'default_focus_background_color': 'light gray',
-                'project_focus_background_color': 'light gray',
-                'link_focus_background_color': 'light gray',
-                'metadata_focus_background_color': 'light gray',
-                'marked_background_color': 'light blue'
+                'focus_background_color': 'gray',
+                'marked_background_color': 'blue'
             },
 
             'aliases': {
@@ -361,12 +357,6 @@ class _Config:
         except ValueError:
             return Color(self.cp.get('colorscheme', 'context_color'))
 
-    def context_focus_background_color(self):
-        try:
-            return Color(self.cp.getint('colorscheme', 'context_focus_background_color'))
-        except ValueError:
-            return Color(self.cp.get('colorscheme', 'context_focus_background_color'))
-
     def metadata_color(self):
         try:
             return Color(self.cp.getint('colorscheme', 'metadata_color'))
@@ -379,29 +369,11 @@ class _Config:
         except ValueError:
             return Color(self.cp.get('colorscheme', 'link_color'))
 
-    def default_focus_background_color(self):
+    def focus_background_color(self):
         try:
-            return Color(self.cp.getint('colorscheme', 'default_focus_background_color'))
+            return Color(self.cp.getint('colorscheme', 'focus_background_color'))
         except ValueError:
-            return Color(self.cp.get('colorscheme', 'default_focus_background_color'))
-
-    def project_focus_background_color(self):
-        try:
-            return Color(self.cp.getint('colorscheme', 'project_focus_background_color'))
-        except ValueError:
-            return Color(self.cp.get('colorscheme', 'project_focus_background_color'))
-
-    def link_focus_background_color(self):
-        try:
-            return Color(self.cp.getint('colorscheme', 'link_focus_background_color'))
-        except ValueError:
-            return Color(self.cp.get('colorscheme', 'link_focus_background_color'))
-
-    def metadata_focus_background_color(self):
-        try:
-            return Color(self.cp.getint('colorscheme', 'metadata_focus_background_color'))
-        except ValueError:
-            return Color(self.cp.get('colorscheme', 'metadata_focus_background_color'))
+            return Color(self.cp.get('colorscheme', 'focus_background_color'))
 
     def marked_background_color(self):
         try:

--- a/topydo/ui/columns/Main.py
+++ b/topydo/ui/columns/Main.py
@@ -198,6 +198,7 @@ class UIApplication(CLIApplicationBase):
         project_focus_background_color = to_urwid_color(config().project_focus_background_color())
         link_focus_background_color = to_urwid_color(config().link_focus_background_color())
         metadata_focus_background_color = to_urwid_color(config().metadata_focus_background_color())
+        marked_background_color = to_urwid_color(config().marked_background_color())
 
         palette = [
             (PaletteItem.PROJECT, '', '', '', project_color, ''),
@@ -209,7 +210,7 @@ class UIApplication(CLIApplicationBase):
             (PaletteItem.LINK, '', '', '', link_color, ''),
             (PaletteItem.LINK_FOCUS, '', 'light gray', '', link_color, link_focus_background_color),
             (PaletteItem.DEFAULT_FOCUS, '', 'light gray', '', '', default_focus_background_color),
-            (PaletteItem.MARKED, '', 'light blue'),
+            (PaletteItem.MARKED, '', 'light blue', '', '', marked_background_color),
         ]
 
         for C in ascii_uppercase:

--- a/topydo/ui/columns/Main.py
+++ b/topydo/ui/columns/Main.py
@@ -191,19 +191,24 @@ class UIApplication(CLIApplicationBase):
     def _create_color_palette(self):
         project_color = to_urwid_color(config().project_color())
         context_color = to_urwid_color(config().context_color())
+        context_focus_background_color = to_urwid_color(config().context_focus_background_color())
         metadata_color = to_urwid_color(config().metadata_color())
         link_color = to_urwid_color(config().link_color())
+        default_focus_background_color = to_urwid_color(config().default_focus_background_color())
+        project_focus_background_color = to_urwid_color(config().project_focus_background_color())
+        link_focus_background_color = to_urwid_color(config().link_focus_background_color())
+        metadata_focus_background_color = to_urwid_color(config().metadata_focus_background_color())
 
         palette = [
             (PaletteItem.PROJECT, '', '', '', project_color, ''),
-            (PaletteItem.PROJECT_FOCUS, '', 'light gray', '', project_color, None),
+            (PaletteItem.PROJECT_FOCUS, '', 'light gray', '', project_color, project_focus_background_color),
             (PaletteItem.CONTEXT, '', '', '', context_color, ''),
-            (PaletteItem.CONTEXT_FOCUS, '', 'light gray', '', context_color, None),
+            (PaletteItem.CONTEXT_FOCUS, '', 'light gray', '', context_color, context_focus_background_color),
             (PaletteItem.METADATA, '', '', '', metadata_color, ''),
-            (PaletteItem.METADATA_FOCUS, '', 'light gray', '', metadata_color, None),
+            (PaletteItem.METADATA_FOCUS, '', 'light gray', '', metadata_color, metadata_focus_background_color),
             (PaletteItem.LINK, '', '', '', link_color, ''),
-            (PaletteItem.LINK_FOCUS, '', 'light gray', '', link_color, None),
-            (PaletteItem.DEFAULT_FOCUS, 'black', 'light gray'),
+            (PaletteItem.LINK_FOCUS, '', 'light gray', '', link_color, link_focus_background_color),
+            (PaletteItem.DEFAULT_FOCUS, '', 'light gray', '', '', default_focus_background_color),
             (PaletteItem.MARKED, '', 'light blue'),
         ]
 

--- a/topydo/ui/columns/Main.py
+++ b/topydo/ui/columns/Main.py
@@ -191,25 +191,21 @@ class UIApplication(CLIApplicationBase):
     def _create_color_palette(self):
         project_color = to_urwid_color(config().project_color())
         context_color = to_urwid_color(config().context_color())
-        context_focus_background_color = to_urwid_color(config().context_focus_background_color())
         metadata_color = to_urwid_color(config().metadata_color())
         link_color = to_urwid_color(config().link_color())
-        default_focus_background_color = to_urwid_color(config().default_focus_background_color())
-        project_focus_background_color = to_urwid_color(config().project_focus_background_color())
-        link_focus_background_color = to_urwid_color(config().link_focus_background_color())
-        metadata_focus_background_color = to_urwid_color(config().metadata_focus_background_color())
+        focus_background_color = to_urwid_color(config().focus_background_color())
         marked_background_color = to_urwid_color(config().marked_background_color())
 
         palette = [
             (PaletteItem.PROJECT, '', '', '', project_color, ''),
-            (PaletteItem.PROJECT_FOCUS, '', 'light gray', '', project_color, project_focus_background_color),
+            (PaletteItem.PROJECT_FOCUS, '', 'light gray', '', project_color, focus_background_color),
             (PaletteItem.CONTEXT, '', '', '', context_color, ''),
-            (PaletteItem.CONTEXT_FOCUS, '', 'light gray', '', context_color, context_focus_background_color),
+            (PaletteItem.CONTEXT_FOCUS, '', 'light gray', '', context_color, focus_background_color),
             (PaletteItem.METADATA, '', '', '', metadata_color, ''),
-            (PaletteItem.METADATA_FOCUS, '', 'light gray', '', metadata_color, metadata_focus_background_color),
+            (PaletteItem.METADATA_FOCUS, '', 'light gray', '', metadata_color, focus_background_color),
             (PaletteItem.LINK, '', '', '', link_color, ''),
-            (PaletteItem.LINK_FOCUS, '', 'light gray', '', link_color, link_focus_background_color),
-            (PaletteItem.DEFAULT_FOCUS, '', 'light gray', '', '', default_focus_background_color),
+            (PaletteItem.LINK_FOCUS, '', 'light gray', '', link_color, focus_background_color),
+            (PaletteItem.DEFAULT_FOCUS, '', 'light gray', '', '', focus_background_color),
             (PaletteItem.MARKED, '', 'light blue', '', '', marked_background_color),
         ]
 
@@ -223,7 +219,7 @@ class UIApplication(CLIApplicationBase):
                 'pri_' + C, '', '', '', pri_color, ''
             ))
             palette.append((
-                'pri_' + C + '_focus', '', 'light gray', '', pri_color_focus, None
+                'pri_' + C + '_focus', '', 'light gray', '', pri_color_focus, focus_background_color
             ))
 
         return palette


### PR DESCRIPTION
This patch allows the background colors of focused and marked todos to be configured using new configuration options.

With these values:

```
[colorscheme]
focus_background_color = 8
marked_background_color = 16
```

My terminal displays this:

![screen shot 2016-11-21 at 11 45 54 am](https://cloud.githubusercontent.com/assets/94535/20497966/1806a064-afe0-11e6-98ae-4accca05b76f.png)

Defaults are working.

Addresses #140 