### PR TITLE
Don't crash on FileNotFoundError with `add -f`

### DIFF
--- a/test/test_add_command.py
+++ b/test/test_add_command.py
@@ -140,7 +140,7 @@ class AddCommandTest(CommandTest):
                          self.today + " Bar id:1")
         self.assertEqual(self.errors, "")
 
-    def test_add_de04(self):
+    def test_add_dep04(self):
         """ Test for using an after: tag with non-existing value. """
         command = AddCommand.AddCommand(["Foo after:1"], self.todolist,
                                         self.out, self.error)
@@ -375,6 +375,13 @@ class AddCommandTest(CommandTest):
 
         self.assertEqual(self.output, u"|  1| {tod} Foo @fo\u00f3b\u0105r due:{tod} id:1\n|  2| {tod} Bar +baz t:{tod} p:1\n".format(tod=self.today))
         self.assertEqual(self.errors, "")
+
+    def test_add_file_not_found(self):
+        command = AddCommand.AddCommand(["-f", "test/data/AddCommandTest-from_Foo.txt"], self.todolist, self.out, self.error)
+        command.execute()
+
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "File not found: test/data/AddCommandTest-from_Foo.txt\n")
 
     def test_add_task_without_date(self):
         config(p_overrides={('add', 'auto_creation_date'): '0'})

--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -86,10 +86,13 @@ class AddCommand(WriteCommand):
         self._process_flags()
 
         if self.from_file:
-            new_todos = self.get_todos_from_file()
+            try:
+                new_todos = self.get_todos_from_file()
 
-            for todo in new_todos:
-                self._add_todo(todo)
+                for todo in new_todos:
+                    self._add_todo(todo)
+            except (IOError, OSError):
+                self.error('File not found: ' + self.from_file)
         else:
             if self.text:
                 self._add_todo(self.text)


### PR DESCRIPTION
Show descriptive error message instead.