### PR TITLE
Prefer filterexpr if there is no title in config

### DIFF
--- a/topydo/ui/columns/ColumnLayout.py
+++ b/topydo/ui/columns/ColumnLayout.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import configparser
+from configparser import RawConfigParser, NoOptionError
 from os.path import expanduser
 
 from topydo.lib.Config import home_config_path, config
@@ -27,8 +27,15 @@ def columns(p_alt_layout_path=None):
     def _get_column_dict(p_cp, p_column):
         column_dict = dict()
 
-        column_dict['title'] = p_cp.get(p_column, 'title')
-        column_dict['filterexpr'] = p_cp.get(p_column, 'filterexpr')
+        filterexpr = p_cp.get(p_column, 'filterexpr')
+
+        try:
+            title = p_cp.get(p_column, 'title')
+        except NoOptionError:
+            title = filterexpr
+
+        column_dict['title'] = title or 'Yet another column'
+        column_dict['filterexpr'] = filterexpr
         column_dict['sortexpr'] = p_cp.get(p_column, 'sortexpr')
         column_dict['groupexpr'] = p_cp.get(p_column, 'groupexpr')
         column_dict['show_all'] = p_cp.getboolean(p_column, 'show_all')
@@ -36,14 +43,13 @@ def columns(p_alt_layout_path=None):
         return column_dict
 
     defaults = {
-            'title':  'Yet another column',
             'filterexpr': '',
             'sortexpr': config().sort_string(),
             'groupexpr': config().group_string(),
             'show_all': '0',
     }
 
-    cp = configparser.RawConfigParser(defaults)
+    cp = RawConfigParser(defaults)
     files = [
         "topydo_columns.ini",
         "topydo_columns.conf",


### PR DESCRIPTION
Use 'Yet another column' only if there is no title and filterexpr is also empty. This behavior is in accordance with change introduced in fc154914a24b313e2cecbfd55b7147bcaa8ea37e.