### PR TITLE
Introduce 'before' and 'after' keywords to `dep ls`

### DIFF
--- a/test/test_dep_command.py
+++ b/test/test_dep_command.py
@@ -271,6 +271,42 @@ class DepCommandTest(CommandTest):
         self.assertEqual(self.errors, "Invalid todo number given.\n")
 
     def test_ls5(self):
+        command = DepCommand(["ls", "before", "1"], self.todolist, self.out,
+                             self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "|  2| Bar p:1\n|  3| Baz p:1\n")
+        self.assertEqual(self.errors, "")
+
+    def test_ls6(self):
+        command = DepCommand(["ls", "before", "99"], self.todolist, self.out,
+                             self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "Invalid todo number given.\n")
+
+    def test_ls7(self):
+        command = DepCommand(["ls", "after", "3"], self.todolist, self.out,
+                             self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "|  1| Foo id:1\n")
+        self.assertEqual(self.errors, "")
+
+    def test_ls8(self):
+        command = DepCommand(["ls", "after", "99"], self.todolist, self.out,
+                             self.error)
+        command.execute()
+
+        self.assertFalse(self.todolist.dirty)
+        self.assertEqual(self.output, "")
+        self.assertEqual(self.errors, "Invalid todo number given.\n")
+
+    def test_ls9(self):
         command = DepCommand(["ls", "1"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -278,7 +314,7 @@ class DepCommandTest(CommandTest):
         self.assertEqual(self.output, "")
         self.assertEqual(self.errors, command.usage() + "\n")
 
-    def test_ls6(self):
+    def test_ls10(self):
         command = DepCommand(["ls"], self.todolist, self.out, self.error)
         command.execute()
 
@@ -286,7 +322,7 @@ class DepCommandTest(CommandTest):
         self.assertFalse(self.output)
         self.assertEqual(self.errors, command.usage() + "\n")
 
-    def test_ls7(self):
+    def test_ls11(self):
         command = DepCommand(["ls", "top", "99"], self.todolist, self.out,
                              self.error)
         command.execute()

--- a/topydo/commands/DepCommand.py
+++ b/topydo/commands/DepCommand.py
@@ -119,13 +119,12 @@ class DepCommand(Command):
                 todo = self.todolist.todo(number)
                 todos = self.todolist.parents(todo)
             else:
-                self.error(self.usage())
+                raise InvalidCommandArgument
 
-            if todos:
-                sorter = Sorter(config().sort_string())
-                instance_filter = Filter.InstanceFilter(todos)
-                view = View(sorter, [instance_filter], self.todolist)
-                self.out(self.printer.print_list(view.todos))
+            sorter = Sorter(config().sort_string())
+            instance_filter = Filter.InstanceFilter(todos)
+            view = View(sorter, [instance_filter], self.todolist)
+            self.out(self.printer.print_list(view.todos))
         except InvalidTodoException:
             self.error("Invalid todo number given.")
         except InvalidCommandArgument:

--- a/topydo/commands/DepCommand.py
+++ b/topydo/commands/DepCommand.py
@@ -108,13 +108,13 @@ class DepCommand(Command):
             arg2 = self.argument(2)
 
             todos = []
-            if arg2 == 'to':
-                # dep ls 1 to ...
-                number = arg1
+            if arg2 == 'to' or arg1 == 'before':
+                # dep ls 1 to OR dep ls before 1
+                number = arg1 if arg2 == 'to' else arg2
                 todo = self.todolist.todo(number)
                 todos = self.todolist.children(todo)
-            elif arg1 == 'to':
-                # dep ls ... to 1
+            elif arg1 in {'to', 'after'}:
+                # dep ls to 1 OR dep ls after 1
                 number = arg2
                 todo = self.todolist.todo(number)
                 todos = self.todolist.parents(todo)
@@ -176,6 +176,7 @@ class DepCommand(Command):
   dep add <NUMBER> <before|partof|after|parents-of|children-of> <NUMBER>
   dep ls <NUMBER> to
   dep ls to <NUMBER>
+  dep ls <before|after> <NUMBER>
   dep dot <NUMBER>
   dep clean"""
 


### PR DESCRIPTION
From now on:
`topydo dep ls before 1` gives the same output as `topydo dep ls 1 to`
and:
`topydo dep ls after 1` gives the same output as `topydo dep ls to 1`