### PR TITLE
Add possibility to trigger actions after archiving

### DIFF
--- a/test/test_delete_command.py
+++ b/test/test_delete_command.py
@@ -47,6 +47,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["1"], self.todolist, self.out, self.error,
                                 _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.todo(1).source(), "Bar")
@@ -57,6 +58,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["Foo"], self.todolist, self.out, self.error,
                                 _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.todo(1).source(), "Bar")
@@ -67,6 +69,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["1"], self.todolist, self.out, self.error,
                                 _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.count(), 2)
@@ -78,6 +81,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["-f", "1"], self.todolist, self.out,
                                 self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.count(), 3)  # force won't delete subtasks
@@ -88,6 +92,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["--force", "1"], self.todolist, self.out,
                                 self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.count(), 3)  # force won't delete subtasks
@@ -97,6 +102,7 @@ class DeleteCommandTest(CommandTest):
     def test_del5(self):
         command = DeleteCommand(["2"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.todo(1).source(), "Foo")
@@ -106,6 +112,7 @@ class DeleteCommandTest(CommandTest):
     def test_del7(self):
         command = DeleteCommand(["99"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "")
@@ -114,6 +121,7 @@ class DeleteCommandTest(CommandTest):
     def test_del8(self):
         command = DeleteCommand(["A"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "")
@@ -125,6 +133,7 @@ class DeleteCommandTest(CommandTest):
 
         command = DeleteCommand(["8to"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "Foo\na @test with due:2015-06-03\na @test with +project"
 
@@ -136,6 +145,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["1", "2"], self.todolist, self.out,
                                 self.error, _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "a @test with due:2015-06-03\na @test with +project"
 
@@ -147,6 +157,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["1", "2"], self.todolist, self.out,
                                 self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "a @test with due:2015-06-03\na @test with +project"
 
@@ -158,6 +169,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["99", "2"], self.todolist, self.out,
                                 self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "")
@@ -168,6 +180,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["99", "A"], self.todolist, self.out,
                                 self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "")
@@ -180,6 +193,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand([u"Fo\u00d3B\u0105r", "Bar"], self.todolist,
                                 self.out, self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.output, "")
@@ -190,6 +204,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["-e", "@test"], self.todolist, self.out,
                                 self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "Removed: a @test with due:2015-06-03\nRemoved: a @test with +project\n"
 
@@ -202,6 +217,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["-e", "@test", "due:2015-06-03"],
                                 self.todolist, self.out, self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "Removed: a @test with due:2015-06-03\n")
@@ -211,6 +227,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["-e", "@test", "due:2015-06-03", "+project"],
                                 self.todolist, self.out, self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
 
@@ -219,6 +236,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["-e", ""], self.todolist, self.out,
                                 self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "Foo"
 
@@ -231,6 +249,7 @@ class DeleteCommandTest(CommandTest):
         command = DeleteCommand(["-xe", ""], self.todolist, self.out,
                                 self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.todolist.count(), 0)
@@ -238,6 +257,7 @@ class DeleteCommandTest(CommandTest):
     def test_empty(self):
         command = DeleteCommand([], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertFalse(self.output)
@@ -251,6 +271,7 @@ class DeleteCommandTest(CommandTest):
     def test_help(self):
         command = DeleteCommand(["help"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.output, "")
         self.assertEqual(self.errors,

--- a/test/test_do_command.py
+++ b/test/test_do_command.py
@@ -60,6 +60,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["3"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertTrue(self.todolist.todo(3).is_completed())
@@ -71,6 +72,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["1"], self.todolist, self.out, self.error,
                             _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "|  2| Bar p:1\n|  3| Baz p:1\nCompleted: x {today} Bar p:1\nCompleted: x {today} Baz p:1\nCompleted: x {today} Foo id:1\n".format(today=self.today)
 
@@ -86,6 +88,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["1"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "|  2| Bar p:1\n|  3| Baz p:1\nCompleted: x {} Foo id:1\n".format(self.today)
 
@@ -106,6 +109,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-f", "1"], self.todolist, self.out, self.error,
                             prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(prompt_shown)
         self.assertEqual(self.errors, "")
@@ -121,6 +125,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["--force", "1"], self.todolist, self.out,
                             self.error, prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(prompt_shown)
         self.assertEqual(self.errors, "")
@@ -129,6 +134,7 @@ class DoCommandTest(CommandTest):
     def _recurrence_helper(self, p_flags):
         command = DoCommand(p_flags, self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.errors, "")
@@ -140,7 +146,9 @@ class DoCommandTest(CommandTest):
         self._recurrence_helper(["4"])
 
         self.assertTrue(self.todolist.todo(4).is_completed())
-        result = "| 12| {today} Recurring! rec:1d due:{tomorrow}\nCompleted: x {today} Recurring! rec:1d\n".format(today=self.today, tomorrow=self.tomorrow)
+        result = """Completed: x {today} Recurring! rec:1d
+The following todo item(s) became active:
+| 12| {today} Recurring! rec:1d due:{tomorrow}\n""".format(today=self.today, tomorrow=self.tomorrow)
         self.assertEqual(self.output, result)
 
         todo = self.todolist.todo(10)
@@ -149,18 +157,23 @@ class DoCommandTest(CommandTest):
 
     def test_strict_recurrence1(self):
         self._recurrence_helper(["-s", "8"])
-        result = "| 12| {today} Strict due:2014-01-02 rec:1d\nCompleted: x {today} Strict due:2014-01-01 rec:1d\n".format(today=self.today)
+        result = """Completed: x {today} Strict due:2014-01-01 rec:1d
+The following todo item(s) became active:
+| 12| {today} Strict due:2014-01-02 rec:1d\n""".format(today=self.today)
         self.assertEqual(self.output, result)
 
     def test_strict_recurrence2(self):
         self._recurrence_helper(["--strict", "8"])
 
-        result = "| 12| {today} Strict due:2014-01-02 rec:1d\nCompleted: x {today} Strict due:2014-01-01 rec:1d\n".format(today=self.today)
+        result = """Completed: x {today} Strict due:2014-01-01 rec:1d
+The following todo item(s) became active:
+| 12| {today} Strict due:2014-01-02 rec:1d\n""".format(today=self.today)
         self.assertEqual(self.output, result)
 
     def test_invalid1(self):
         command = DoCommand(["99"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertFalse(self.output)
@@ -169,6 +182,7 @@ class DoCommandTest(CommandTest):
     def test_invalid2(self):
         command = DoCommand(["AAA"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertFalse(self.output)
@@ -178,6 +192,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["01"], self.todolist, self.out, self.error,
                             _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertFalse(self.output)
@@ -186,6 +201,7 @@ class DoCommandTest(CommandTest):
     def test_activated_todos1(self):
         command = DoCommand(["2"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         first_output = "Completed: x {} Bar p:1\n".format(self.today)
 
@@ -194,6 +210,7 @@ class DoCommandTest(CommandTest):
 
         command = DoCommand(["3"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.output, first_output + "Completed: x {} Baz p:1\nThe following todo item(s) became active:\n|  1| Foo id:1\n".format(self.today))
         self.assertEqual(self.errors, "")
@@ -201,6 +218,7 @@ class DoCommandTest(CommandTest):
     def test_activated_todos2(self):
         command = DoCommand(["7"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.output, "Completed: x {} Subtodo of inactive p:2\n".format(self.today))
         self.assertEqual(self.errors, "")
@@ -208,6 +226,7 @@ class DoCommandTest(CommandTest):
     def test_already_complete(self):
         command = DoCommand(["5"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.todolist.todo(5).completion_date(),
@@ -218,6 +237,7 @@ class DoCommandTest(CommandTest):
     def test_do_regex1(self):
         command = DoCommand(["baz"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertTrue(self.todolist.todo(3).is_completed())
@@ -229,6 +249,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-d", "2014-11-18", "3"], self.todolist, self.out,
                             self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "Completed: x 2014-11-18 Baz p:1\n")
@@ -238,6 +259,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-d", "2014-11-18", "1"], self.todolist, self.out,
                             self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "|  2| Bar p:1\n|  3| Baz p:1\nCompleted: x 2014-11-18 Bar p:1\nCompleted: x 2014-11-18 Baz p:1\nCompleted: x 2014-11-18 Foo id:1\n")
@@ -247,6 +269,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["--date=2014-11-18", "3"], self.todolist,
                             self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "Completed: x 2014-11-18 Baz p:1\n")
@@ -256,6 +279,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-d", "foo", "3"], self.todolist, self.out,
                             self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output,
@@ -270,9 +294,12 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-d", self.yesterday, "4"], self.todolist,
                             self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "| 12| {today} Recurring! rec:1d due:{today}\nCompleted: x {yesterday} Recurring! rec:1d\n".format(today=self.today, yesterday=self.yesterday))
+        self.assertEqual(self.output, """Completed: x {yesterday} Recurring! rec:1d
+The following todo item(s) became active:
+| 12| {today} Recurring! rec:1d due:{today}\n""".format(today=self.today, yesterday=self.yesterday))
         self.assertEqual(self.errors, "")
 
     def test_do_custom_date6(self):
@@ -284,9 +311,12 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-s", "-d", self.yesterday, "4"], self.todolist,
                             self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "| 12| {today} Recurring! rec:1d due:{today}\nCompleted: x {yesterday} Recurring! rec:1d\n".format(today=self.today, yesterday=self.yesterday))
+        self.assertEqual(self.output, """Completed: x {yesterday} Recurring! rec:1d
+The following todo item(s) became active:
+| 12| {today} Recurring! rec:1d due:{today}\n""".format(today=self.today, yesterday=self.yesterday))
         self.assertEqual(self.errors, "")
 
     def test_do_custom_date7(self):
@@ -297,9 +327,12 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-s", "-d", self.yesterday, "8"], self.todolist,
                             self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output, "| 12| {today} Strict due:2014-01-02 rec:1d\nCompleted: x {yesterday} Strict due:2014-01-01 rec:1d\n".format(today=self.today, yesterday=self.yesterday))
+        self.assertEqual(self.output, """Completed: x {yesterday} Strict due:2014-01-01 rec:1d
+The following todo item(s) became active:
+| 12| {today} Strict due:2014-01-02 rec:1d\n""".format(today=self.today, yesterday=self.yesterday))
         self.assertEqual(self.errors, "")
 
     def test_do_custom_date8(self):
@@ -309,10 +342,10 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-d", "yesterday", "3"], self.todolist, self.out,
                             self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
-        self.assertEqual(self.output,
-                         "Completed: x {} Baz p:1\n".format(self.yesterday))
+        self.assertEqual(self.output, "Completed: x {} Baz p:1\n".format(self.yesterday))
         self.assertEqual(self.errors, "")
 
     def test_do_custom_date9(self):
@@ -322,6 +355,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-d", "-1d", "3"], self.todolist, self.out,
                             self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output,
@@ -332,6 +366,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["1", "3"], self.todolist, self.out, self.error,
                             _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.todo(1).is_completed())
         self.assertTrue(self.todolist.todo(2).is_completed())
@@ -343,6 +378,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["1", "3"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.todo(1).is_completed())
         self.assertFalse(self.todolist.todo(2).is_completed())
@@ -354,6 +390,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["3", "3"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.todo(3).is_completed())
         self.assertEqual(self.output,
@@ -363,6 +400,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["99", "3"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.todo(3).is_completed())
         self.assertEqual(self.errors, "Invalid todo number given: 99.\n")
@@ -374,6 +412,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["99", "15"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.errors, "Invalid todo number given: 99.\nInvalid todo number given: 15.\n")
 
@@ -384,6 +423,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand([u"Fo\u00d3B\u0105r", "Bar"], self.todolist,
                             self.out, self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertEqual(self.errors,
@@ -393,6 +433,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-e", "@test"], self.todolist, self.out,
                             self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "Completed: x {t} a @test with due:2015-06-03\nCompleted: x {t} a @test with +project\n".format(t=self.today))
@@ -402,6 +443,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-e", "@test", "due:2015-06-03"], self.todolist,
                             self.out, self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertTrue(self.todolist.dirty)
         self.assertEqual(self.output, "Completed: x {} a @test with due:2015-06-03\n".format(self.today))
@@ -411,6 +453,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-e", "@test", "due:2015-06-03", "+project"],
                             self.todolist, self.out, self.error, None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
 
@@ -419,6 +462,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-e", "Foo"], self.todolist, self.out, self.error,
                             None)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
 
@@ -427,6 +471,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["-xe", "Foo"], self.todolist, self.out,
                             self.error, _yes_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         result = "|  2| Bar p:1\n|  3| Baz p:1\nCompleted: x {t} Bar p:1\nCompleted: x {t} Baz p:1\nCompleted: x {t} Foo id:1\n".format(t=self.today)
 
@@ -441,6 +486,7 @@ class DoCommandTest(CommandTest):
         command = DoCommand(["9"], self.todolist, self.out, self.error,
                             _no_prompt)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.output,
                          "Completed: x {} Invalid rec:1\n".format(self.today))
@@ -449,6 +495,7 @@ class DoCommandTest(CommandTest):
     def test_empty(self):
         command = DoCommand([], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertFalse(self.todolist.dirty)
         self.assertFalse(self.output)
@@ -462,6 +509,7 @@ class DoCommandTest(CommandTest):
     def test_help(self):
         command = DoCommand(["help"], self.todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.output, "")
         self.assertEqual(self.errors,

--- a/test/test_list_project_command.py
+++ b/test/test_list_project_command.py
@@ -26,6 +26,7 @@ class ListProjectCommandTest(CommandTest):
         todolist = load_file_to_todolist("test/data/TodoListTest.txt")
         command = ListProjectCommand([""], todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()  # test default implementation of post_archive
 
         self.assertEqual(self.output, "Project1\nProject2\n")
         self.assertFalse(self.errors)
@@ -34,6 +35,7 @@ class ListProjectCommandTest(CommandTest):
         todolist = load_file_to_todolist("test/data/TodoListTest.txt")
         command = ListProjectCommand(["aaa"], todolist, self.out, self.error)
         command.execute()
+        command.execute_post_archive_actions()
 
         self.assertEqual(self.output, "Project1\nProject2\n")
         self.assertFalse(self.errors)

--- a/topydo/commands/DoCommand.py
+++ b/topydo/commands/DoCommand.py
@@ -18,7 +18,6 @@ from datetime import date
 
 from topydo.lib.DCommand import DCommand
 from topydo.lib.printers.PrettyPrinter import PrettyPrinter
-from topydo.lib.prettyprinters.Numbers import PrettyPrinterNumbers
 from topydo.lib.Recurrence import NoRecurrenceException, advance_recurring_todo
 from topydo.lib.RelativeDate import relative_date_to_date
 from topydo.lib.Utils import date_string_to_date
@@ -67,9 +66,6 @@ class DoCommand(DCommand):
 
                 self.todolist.add_todo(new_todo)
 
-                printer = PrettyPrinter()
-                printer.add_filter(PrettyPrinterNumbers(self.todolist))
-                self.out(printer.print_todo(new_todo))
             except NoRecurrenceException:
                 self.error("Warning: todo item has an invalid recurrence pattern.")
 

--- a/topydo/lib/Command.py
+++ b/topydo/lib/Command.py
@@ -90,6 +90,10 @@ class Command(object):
         """" Returns short-name of the command. """
         return cls.__name__[:-7].lower()  # strip 'Command'
 
+    def execute_post_archive_actions(self):
+        """ Runs various hooks that should take place after archiving. """
+        pass
+
     def usage(self):
         """ Returns a one-line synopsis for this command. """
         raise NotImplementedError

--- a/topydo/ui/CLIApplicationBase.py
+++ b/topydo/ui/CLIApplicationBase.py
@@ -27,7 +27,7 @@ from topydo.lib.TopydoString import TopydoString
 
 MAIN_OPTS = "ac:C:d:ht:v"
 MAIN_LONG_OPTS = ('version')
-READ_ONLY_COMMANDS = ('List', 'ListContext', 'ListProject')
+READ_ONLY_COMMANDS = ('list', 'listcontext', 'listproject')
 
 GENERIC_HELP="""Available commands:
 
@@ -245,9 +245,9 @@ class CLIApplicationBase(object):
 
     def is_read_only(self, p_command):
         """ Returns True when the given command class is read-only. """
-        read_only_commands = tuple(cmd + 'Command' for cmd in ('Revert', ) +
-                READ_ONLY_COMMANDS)
-        return p_command.__module__.endswith(read_only_commands)
+        read_only_commands = tuple(cmd for cmd
+                                   in ('revert', ) + READ_ONLY_COMMANDS)
+        return p_command.name() in read_only_commands
 
     def _backup(self, p_command, p_args=[], p_label=None):
         if config().backup_count() > 0 and p_command and not self.is_read_only(p_command):

--- a/topydo/ui/CLIApplicationBase.py
+++ b/topydo/ui/CLIApplicationBase.py
@@ -174,6 +174,7 @@ class CLIApplicationBase(object):
         self.todolist = TodoList.TodoList([])
         self.todofile = None
         self.do_archive = True
+        self._post_archive_action = None
         self.backup = None
 
     def _usage(self):
@@ -271,6 +272,7 @@ class CLIApplicationBase(object):
             input)
 
         if command.execute() != False:
+            self._post_archive_action = command.execute_post_archive_actions
             return True
 
         return False
@@ -290,6 +292,8 @@ class CLIApplicationBase(object):
             elif config().archive() and self.backup:
                 archive = _retrieve_archive()[0]
                 self.backup.add_archive(archive)
+
+            self._post_archive_action()
 
             if config().keep_sorted():
                 from topydo.commands.SortCommand import SortCommand

--- a/topydo/ui/columns/Main.py
+++ b/topydo/ui/columns/Main.py
@@ -327,6 +327,8 @@ class UIApplication(CLIApplicationBase):
 
         try:
             if transaction.execute():
+                post_archive_action = transaction.execute_post_archive_actions
+                self._post_archive_action = post_archive_action
                 self._post_execute()
             else:
                 self._rollback()

--- a/topydo/ui/columns/Transaction.py
+++ b/topydo/ui/columns/Transaction.py
@@ -27,6 +27,7 @@ class Transaction(object):
         self._cmd = lambda op: p_subcommand(op, *p_env_args)
         self._todo_ids = p_todo_ids
         self._operations = []
+        self._post_archive_actions = []
         self._cmd_name = p_subcommand.name()
         self.label = []
 
@@ -72,5 +73,13 @@ class Transaction(object):
 
             if command.execute() is False:
                 return False
-            elif i == last_operation:
-                return True
+            else:
+                action = command.execute_post_archive_actions
+                self._post_archive_actions.append(action)
+
+                if i == last_operation:
+                    return True
+
+    def execute_post_archive_actions(self):
+        for action in self._post_archive_actions:
+            action()


### PR DESCRIPTION
Each command can now execute action defined in its own Command.post_archive() method after archiving action is done. Hook for `do` and `del` is also included in this change.

This should fix #139