### PR TITLE
Add possibility to list all backups and revert to specific point in history

### DIFF
--- a/test/test_revert_command.py
+++ b/test/test_revert_command.py
@@ -77,7 +77,7 @@ class RevertCommandTest(CommandTest):
         result = TodoList(self.archive_file.read()).print_todos()
 
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: do 1\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: do 1\n"))
         self.assertEqual(result, "")
         self.assertEqual(self.todolist.print_todos(), "Foo\nBar\nBaz")
 
@@ -109,7 +109,7 @@ class RevertCommandTest(CommandTest):
         result = TodoList(self.archive_file.read()).print_todos()
 
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: do Bar\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: do Bar\n"))
         self.assertEqual(result, "x {} Foo".format(self.today))
         self.assertEqual(self.todolist.print_todos(), "Bar\nBaz")
 
@@ -182,7 +182,7 @@ class RevertCommandTest(CommandTest):
         self.assertEqual(len(changesets), 4)
         self.assertEqual(result, [])
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: add Seven\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: add Seven\n"))
 
     def test_revert05(self):
         """ Test for possible backup collisions """
@@ -219,31 +219,31 @@ class RevertCommandTest(CommandTest):
         revert_command = RevertCommand([], self.todolist, self.out, self.error, None)
         revert_command.execute()
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: add Four\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: add Four\n"))
         self.assertEqual(self.todolist.print_todos(), "Foo\nBar\nBaz\n{t} One\n{t} Two".format(t=self.today))
 
         revert_command = RevertCommand([], self.todolist, self.out, self.error, None)
         revert_command.execute()
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: delete Three\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: delete Three\n"))
         self.assertEqual(self.todolist.print_todos(), "Foo\nBar\nBaz\n{t} One\n{t} Two\n{t} Three".format(t=self.today))
 
         revert_command = RevertCommand([], self.todolist, self.out, self.error, None)
         revert_command.execute()
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: add Three\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: add Three\n"))
         self.assertEqual(self.todolist.print_todos(), "Foo\nBar\nBaz\n{t} One\n{t} Two".format(t=self.today))
 
         revert_command = RevertCommand([], self.todolist, self.out, self.error, None)
         revert_command.execute()
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: add Two\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: add Two\n"))
         self.assertEqual(self.todolist.print_todos(), "Foo\nBar\nBaz\n{t} One".format(t=self.today))
 
         revert_command = RevertCommand([], self.todolist, self.out, self.error, None)
         revert_command.execute()
         self.assertEqual(self.errors, "")
-        self.assertTrue(self.output.endswith("Successfully reverted: add One\n"))
+        self.assertTrue(self.output.endswith("Reverted to state before: add One\n"))
         self.assertEqual(self.todolist.print_todos(), "Foo\nBar\nBaz")
 
     def test_revert06(self):

--- a/topydo/commands/RevertCommand.py
+++ b/topydo/commands/RevertCommand.py
@@ -70,7 +70,7 @@ class RevertCommand(Command):
 
     def _revert_to_specific(self, p_position):
         timestamps = [timestamp for timestamp, _ in self._backup]
-        position = int(p_position)
+        position = int(p_position) - 1
         try:
             timestamp = timestamps[position]
             self._revert(timestamp)
@@ -93,7 +93,7 @@ class RevertCommand(Command):
             self.error(self.usage())
 
     def _handle_ls(self):
-        num = 0
+        num = 1
         changes = []
         for timestamp, change in self._backup:
             label = change[2]

--- a/topydo/commands/RevertCommand.py
+++ b/topydo/commands/RevertCommand.py
@@ -94,15 +94,12 @@ class RevertCommand(Command):
 
     def _handle_ls(self):
         num = 1
-        changes = []
         for timestamp, change in self._backup:
             label = change[2]
             time = arrow.get(timestamp).format('YYYY-MM-DD HH:mm:ss')
 
-            changes.append(str(num) + ' | ' + time + ' | ' + label + '\n')
+            self.out('{0: >3}| {1} | {2}'.format(str(num), time, label))
             num += 1
-
-        self.out(''.join(changes).rstrip())
 
     def usage(self):
         return """Synopsis: revert"""

--- a/topydo/commands/RevertCommand.py
+++ b/topydo/commands/RevertCommand.py
@@ -16,8 +16,8 @@
 
 import arrow
 
-from topydo.lib.Command import Command, InvalidCommandArgument
 from topydo.lib.ChangeSet import ChangeSet
+from topydo.lib.Command import Command, InvalidCommandArgument
 from topydo.lib import TodoFile
 from topydo.lib import TodoList
 from topydo.lib.Config import config
@@ -56,14 +56,12 @@ class RevertCommand(Command):
         self._backup.close()
 
     def _revert(self, p_timestamp=None):
-        if p_timestamp is None:
-            self._backup.get_backup_from_todolist(self.todolist)
-        else:
-            self._backup.get_backup_from_timestamp(p_timestamp)
-
+        self._backup.get_backup(self.todolist, p_timestamp)
         self._backup.apply(self.todolist, self._archive)
+
         if self._archive:
             self._archive_file.write(self._archive.print_todos())
+
         self.out("Reverted to state before: " + self._backup.label)
 
     def _revert_last(self):
@@ -77,7 +75,7 @@ class RevertCommand(Command):
             timestamp = timestamps[position]
             self._revert(timestamp)
             for timestamp in timestamps[:position + 1]:
-                self._backup.get_backup_from_timestamp(timestamp)
+                self._backup.get_backup(p_timestamp=timestamp)
                 self._backup.delete()
         except IndexError:
             self.error('Specified index is out range')

--- a/topydo/commands/RevertCommand.py
+++ b/topydo/commands/RevertCommand.py
@@ -56,7 +56,7 @@ class RevertCommand(Command):
         self._backup.close()
 
     def _revert(self, p_timestamp=None):
-        self._backup.get_backup(self.todolist, p_timestamp)
+        self._backup.read_backup(self.todolist, p_timestamp)
         self._backup.apply(self.todolist, self._archive)
 
         if self._archive:
@@ -75,7 +75,7 @@ class RevertCommand(Command):
             timestamp = timestamps[position]
             self._revert(timestamp)
             for timestamp in timestamps[:position + 1]:
-                self._backup.get_backup(p_timestamp=timestamp)
+                self._backup.read_backup(p_timestamp=timestamp)
                 self._backup.delete()
         except IndexError:
             self.error('Specified index is out range')

--- a/topydo/lib/ChangeSet.py
+++ b/topydo/lib/ChangeSet.py
@@ -56,6 +56,11 @@ class ChangeSet(object):
 
         self._read()
 
+    def __iter__(self):
+        items = {key: self.backup_dict[key]
+                 for key in self.backup_dict if key != 'index'}.items()
+        return iter(sorted(items, reverse=True))
+
     def _read(self):
         """
         Reads backup file from json_file property and sets backup_dict property
@@ -158,7 +163,18 @@ class ChangeSet(object):
         for changeset in index[backup_limit:]:
             self.delete(changeset[0], p_write=False)
 
-    def get_backup(self, p_todolist):
+    def _get_backup(self):
+        d = self.backup_dict[self.timestamp]
+
+        self.todolist = TodoList(d[0])
+        self.archive = TodoList(d[1])
+        self.label = d[2]
+
+    def get_backup_from_timestamp(self, p_timestamp):
+        self.timestamp = p_timestamp
+        self._get_backup()
+
+    def get_backup_from_todolist(self, p_todolist):
         """
         Retrieves a backup for p_todolist from backup file and sets todolist,
         archive and label attributes to appropriate data from it.
@@ -167,12 +183,7 @@ class ChangeSet(object):
 
         index = self._get_index()
         self.timestamp = index[[change[1] for change in index].index(change_hash)][0]
-
-        d = self.backup_dict[self.timestamp]
-
-        self.todolist = TodoList(d[0])
-        self.archive = TodoList(d[1])
-        self.label = d[2]
+        self._get_backup()
 
     def apply(self, p_todolist, p_archive):
         """ Applies backup on supplied p_todolist. """

--- a/topydo/lib/ChangeSet.py
+++ b/topydo/lib/ChangeSet.py
@@ -46,7 +46,7 @@ class ChangeSet(object):
     def __init__(self, p_todolist=None, p_archive=None, p_label=[]):
         self.todolist = deepcopy(p_todolist)
         self.archive = deepcopy(p_archive)
-        self.timestamp = str(int(time.time()))
+        self.timestamp = str(time.time())
         self.label = ' '.join(p_label)
 
         try:

--- a/topydo/lib/ChangeSet.py
+++ b/topydo/lib/ChangeSet.py
@@ -163,27 +163,19 @@ class ChangeSet(object):
         for changeset in index[backup_limit:]:
             self.delete(changeset[0], p_write=False)
 
-    def _get_backup(self):
+    def get_backup(self, p_todolist=None, p_timestamp=None):
+        if not p_timestamp:
+            change_hash = hash_todolist(p_todolist)
+            index = self._get_index()
+            self.timestamp = index[[change[1] for change in index].index(change_hash)][0]
+        else:
+            self.timestamp = p_timestamp
+
         d = self.backup_dict[self.timestamp]
 
         self.todolist = TodoList(d[0])
         self.archive = TodoList(d[1])
         self.label = d[2]
-
-    def get_backup_from_timestamp(self, p_timestamp):
-        self.timestamp = p_timestamp
-        self._get_backup()
-
-    def get_backup_from_todolist(self, p_todolist):
-        """
-        Retrieves a backup for p_todolist from backup file and sets todolist,
-        archive and label attributes to appropriate data from it.
-        """
-        change_hash = hash_todolist(p_todolist)
-
-        index = self._get_index()
-        self.timestamp = index[[change[1] for change in index].index(change_hash)][0]
-        self._get_backup()
 
     def apply(self, p_todolist, p_archive):
         """ Applies backup on supplied p_todolist. """

--- a/topydo/lib/ChangeSet.py
+++ b/topydo/lib/ChangeSet.py
@@ -163,7 +163,7 @@ class ChangeSet(object):
         for changeset in index[backup_limit:]:
             self.delete(changeset[0], p_write=False)
 
-    def get_backup(self, p_todolist=None, p_timestamp=None):
+    def read_backup(self, p_todolist=None, p_timestamp=None):
         if not p_timestamp:
             change_hash = hash_todolist(p_todolist)
             index = self._get_index()

--- a/topydo/lib/ChangeSet.py
+++ b/topydo/lib/ChangeSet.py
@@ -176,10 +176,10 @@ class ChangeSet(object):
 
     def apply(self, p_todolist, p_archive):
         """ Applies backup on supplied p_todolist. """
-        if self.todolist:
+        if self.todolist and p_todolist:
             p_todolist.replace(self.todolist.todos())
 
-        if self.archive:
+        if self.archive and p_archive:
             p_archive.replace(self.archive.todos())
 
     def close(self):


### PR DESCRIPTION
`topydo revert ls` will give a list of all backup points (one line each) in form:

`0 | YYYY-MM-DD HH:mm | label`

~~`topydo revert 2` will revert to backup point marked as 2 (i.e. 3 changes back in history, because we're counting from 0).~~ **Changed in f17c9a0:** Numbering of `topydo revert ls` starts now from **1** and `topydo revert 2` will revert last *two* changes (i.e. to the state **before** change marked as **2** in `revert ls`).

Also fixed one nasty bug in `RevertCommand`
steps to reproduce:                                                                                                                                   
1. Enable archiving and backups
2. Mark some tasks as done to fill archive file
3. Disable archiving (set archive_filename to blank)
4. `topydo revert`

Results: topydo tries to write backuped archive content into nonexistent file:
```
Traceback (most recent call last):
  File "/home/jacek/.local/bin/topydo", line 11, in <module>
    load_entry_point('topydo==0.12', 'console_scripts', 'topydo')()
  File "/home/jacek/.local/lib/python3.5/site-packages/topydo/ui/UILoader.py", line 55, in main
    CLIApplication().run()
  File "/home/jacek/.local/lib/python3.5/site-packages/topydo/ui/cli/CLI.py", line 62, in run
    if self._execute(subcommand, args) == False:
  File "/home/jacek/.local/lib/python3.5/site-packages/topydo/ui/CLIApplicationBase.py", line 273, in _execute
    if command.execute() != False:
  File "/home/jacek/.local/lib/python3.5/site-packages/topydo/commands/RevertCommand.py", line 43, in execute
    archive_file.write(archive.print_todos())
  File "/home/jacek/.local/lib/python3.5/site-packages/topydo/lib/TodoFile.py", line 54, in write
    todofile = codecs.open(self.path, 'w', encoding="utf-8")
  File "/usr/lib64/python3.5/codecs.py", line 895, in open
    file = builtins.open(filename, mode, buffering)
IsADirectoryError: [Errno 21] Is a directory: '/home/jacek'
```