### PR TITLE
Fix handling of todo items with same source text inside Column UI

### DIFF
--- a/test/test_list_command.py
+++ b/test/test_list_command.py
@@ -288,7 +288,7 @@ class ListCommandTest(CommandTest):
         self.assertEqual(self.errors, "")
 
     def test_list37(self):
-        command = ListCommand(["-i", "1,foo,3"], self.todolist, self.out, self.error)
+        command = ListCommand(["-i", "1", "foo", "3"], self.todolist, self.out, self.error)
         command.execute()
 
         self.assertEqual(self.output, "|  1| (C) 2015-11-05 Foo @Context2 Not@Context +Project1 Not+Project\n|  3| (C) Baz @Context1 +Project1 key:value\n")
@@ -297,7 +297,7 @@ class ListCommandTest(CommandTest):
     def test_list38(self):
         config("test/data/todolist-uid.conf")
 
-        command = ListCommand(["-i", "1,foo,z63"], self.todolist, self.out, self.error)
+        command = ListCommand(["-i", "1", "foo", "z63"], self.todolist, self.out, self.error)
         command.execute()
 
         self.assertEqual(self.output, "|t5c| (C) 2015-11-05 Foo @Context2 Not@Context +Project1 Not+Project\n|z63| (C) 13 + 29 = 42\n")
@@ -306,7 +306,7 @@ class ListCommandTest(CommandTest):
     def test_list39(self):
         config("test/data/todolist-uid.conf")
 
-        command = ListCommand(["-i", "t5c,foo"], self.todolist, self.out, self.error)
+        command = ListCommand(["-i", "t5c", "foo"], self.todolist, self.out, self.error)
         command.execute()
 
         self.assertEqual(self.output, "|t5c| (C) 2015-11-05 Foo @Context2 Not@Context +Project1 Not+Project\n")

--- a/topydo/commands/ListCommand.py
+++ b/topydo/commands/ListCommand.py
@@ -59,7 +59,7 @@ class ListCommand(ExpressionCommand):
         return True
 
     def _process_flags(self):
-        opts, args = self.getopt('f:F:g:i:n:Ns:x')
+        opts, args = self.getopt('f:F:g:in:Ns:x')
 
         for opt, value in opts:
             if opt == '-x':
@@ -97,7 +97,10 @@ class ListCommand(ExpressionCommand):
                 except ValueError:
                     pass  # use default value in configuration
             elif opt == '-i':
-                self.ids = value.split(',')
+                self.ids = args
+                # don't show args to other filters - user requested only
+                # specific IDs
+                args = []
 
                 # when a user requests a specific ID, it should always be shown
                 self.show_all = True
@@ -176,7 +179,7 @@ class ListCommand(ExpressionCommand):
 
             Otherwise, it looks for a newline ('\n') in the environmental variable
             PS1.
-        '''  
+        '''
         lines_in_prompt = 1     # prompt is assumed to take up one line, even
                                 #   without any newlines in it
         if "win32" in sys.platform:

--- a/topydo/lib/Command.py
+++ b/topydo/lib/Command.py
@@ -77,8 +77,24 @@ class Command(object):
     def getopt(self, p_flags, p_long=None):
         p_long = p_long or []
 
+        args_copy = self.args[:]
+        non_safe_args = []
+        non_safe_arg_placeholder = '<non_text_arg>'
+
+        # filter out non-text args and store them for later use
+        for arg in args_copy:
+            if not isinstance(arg, str):
+                args_copy[args_copy.index(arg)] = non_safe_arg_placeholder
+                non_safe_args.append(arg)
         try:
-            result = getopt.getopt(self.args, p_flags, p_long)
+            flags, args = getopt.getopt(args_copy, p_flags, p_long)
+
+            # reapply non-text args in their proper place
+            for arg in args:
+                if arg == non_safe_arg_placeholder:
+                    args[args.index(arg)] = non_safe_args.pop(0)
+
+            result = (flags, args)
         except getopt.GetoptError as goe:
             self.error(str(goe))
             result = ([], self.args)

--- a/topydo/lib/TodoListBase.py
+++ b/topydo/lib/TodoListBase.py
@@ -125,16 +125,22 @@ class TodoListBase(object):
 
             return result
 
-        result = todo_by_uid(p_identifier)
+        try:
+            result = todo_by_uid(p_identifier)
 
-        if not result:
-            result = todo_by_linenumber(p_identifier)
+            if not result:
+                result = todo_by_linenumber(p_identifier)
 
-        if not result:
-            # convert integer to text so we pass on a valid regex
-            result = todo_by_regexp(str(p_identifier))
+            if not result:
+                # convert integer to text so we pass on a valid regex
+                result = todo_by_regexp(str(p_identifier))
 
-        return result
+            return result
+        except InvalidTodoException:
+            if p_identifier in self._todos:
+                return p_identifier
+            else:
+                raise
 
     def add(self, p_src):
         """

--- a/topydo/lib/TodoListBase.py
+++ b/topydo/lib/TodoListBase.py
@@ -104,7 +104,7 @@ class TodoListBase(object):
                 except TypeError as te:
                     try:
                         result = self._todos[int(p_identifier) - 1]
-                    except (ValueError, IndexError):
+                    except (ValueError, IndexError, TypeError):
                         raise InvalidTodoException from te
 
             return result

--- a/topydo/ui/columns/TodoListWidget.py
+++ b/topydo/ui/columns/TodoListWidget.py
@@ -215,8 +215,7 @@ class TodoListWidget(urwid.LineBox):
 
     def _toggle_marked_status(self):
         try:
-            todo = self.listbox.focus.todo
-            todo_id = str(self.view.todolist.number(todo))
+            todo_id = self.listbox.focus.number
             if urwid.emit_signal(self, 'toggle_mark', todo_id):
                 self.listbox.focus.mark()
             else:
@@ -243,8 +242,7 @@ class TodoListWidget(urwid.LineBox):
         be one of 'execute_command' or 'execute_command_silent'.
         """
         try:
-            todo = self.listbox.focus.todo
-            todo_id = str(self.view.todolist.number(todo))
+            todo_id = self.listbox.focus.number
 
             urwid.emit_signal(self, p_execute_signal, p_cmd_str, todo_id)
 
@@ -371,8 +369,7 @@ class TodoListWidget(urwid.LineBox):
 
     def _repeat_cmd(self):
         try:
-            todo = self.listbox.focus.todo
-            todo_id = str(self.view.todolist.number(todo))
+            todo_id = self.listbox.focus.number
         except AttributeError:
             todo_id = None
 

--- a/topydo/ui/columns/TodoListWidget.py
+++ b/topydo/ui/columns/TodoListWidget.py
@@ -99,7 +99,8 @@ class TodoListWidget(urwid.LineBox):
                 self.todolist.append(urwid.Divider('-'))
 
             for todo in todos:
-                todowidget = TodoWidget.create(todo)
+                text_id = self.view.todolist.uid(todo)
+                todowidget = TodoWidget.create(todo, text_id)
                 todowidget.number = self.view.todolist.number(todo)
                 self.todolist.append(todowidget)
                 self.todolist.append(urwid.Divider('-'))

--- a/topydo/ui/columns/TodoListWidget.py
+++ b/topydo/ui/columns/TodoListWidget.py
@@ -99,9 +99,13 @@ class TodoListWidget(urwid.LineBox):
                 self.todolist.append(urwid.Divider('-'))
 
             for todo in todos:
-                text_id = self.view.todolist.uid(todo)
+                todo_id = self.view.todolist.number(todo)
+                text_id = todo_id
+                if not isinstance(text_id, str):
+                    text_id = self.view.todolist.uid(todo)
+
                 todowidget = TodoWidget.create(todo, text_id)
-                todowidget.number = self.view.todolist.number(todo)
+                todowidget.number = todo_id
                 self.todolist.append(todowidget)
                 self.todolist.append(urwid.Divider('-'))
 

--- a/topydo/ui/columns/TodoWidget.py
+++ b/topydo/ui/columns/TodoWidget.py
@@ -130,7 +130,7 @@ class TodoWidget(urwid.WidgetWrap):
 
     @property
     def number(self):
-        pass
+        return self.id_widget.text
 
     @number.setter
     def number(self, p_number):

--- a/topydo/ui/columns/TodoWidget.py
+++ b/topydo/ui/columns/TodoWidget.py
@@ -159,7 +159,7 @@ class TodoWidget(urwid.WidgetWrap):
     cache = {}
 
     @classmethod
-    def create(p_class, p_todo):
+    def create(p_class, p_todo, p_text_id):
         """
         Creates a TodoWidget instance for the given todo. Widgets are
         cached, the same object is returned for the same todo item.
@@ -174,8 +174,8 @@ class TodoWidget(urwid.WidgetWrap):
 
         source = p_todo.source()
 
-        if source in p_class.cache:
-            widget = p_class.cache[source]
+        if (source, p_text_id) in p_class.cache:
+            widget = p_class.cache[(source, p_text_id)]
 
             if p_todo is not widget.todo:
                 # same source text but different todo instance (could happen
@@ -188,7 +188,7 @@ class TodoWidget(urwid.WidgetWrap):
                 widget.update_progress()
         else:
             widget = p_class(p_todo)
-            p_class.cache[source] = widget
+            p_class.cache[(source, p_text_id)] = widget
 
         return widget
 

--- a/topydo/ui/columns/Transaction.py
+++ b/topydo/ui/columns/Transaction.py
@@ -48,7 +48,7 @@ class Transaction(object):
                 p_args[id_position:id_position + 1] = self._todo_ids
                 self._operations.append(p_args)
             else:
-                for todo_id in self._todo_ids:
+                for todo_id in sorted(self._todo_ids):
                     todo = self._todolist.todo(todo_id)
                     operation_args = p_args[:]
                     operation_args[id_position] = todo


### PR DESCRIPTION
Combining source text and text_id as a cache key ensures that we don't create "false positive" hits while searching cache (for instance when multiple todo items with same source text are present whithin TodoList).

Also use `TodoWidget.number` for obtaining todo id when it's needed, and pass `Todo` objects to non-multi commands instead of textual ids to ensure that each command inside `Transaction` operates on `Todo` picked by the user.

Minor backward-compatibility issue will occur after merging this:
`topydo ls -i 1,2` will no longer work. Proper call to show specific todo items would be:
`topydo ls -i 1 2`.