### PR TITLE
Extend `dep` command

### DIFF
--- a/topydo/commands/DepCommand.py
+++ b/topydo/commands/DepCommand.py
@@ -40,8 +40,31 @@ class DepCommand(Command):
         self.printer = pretty_printer_factory(self.todolist)
 
     def _handle_add(self):
+        from_todos = []
+        to_todos = []
+
         for from_todo, to_todo in self._get_todos():
             self.todolist.add_dependency(from_todo, to_todo)
+
+            if from_todo not in from_todos:
+                from_todos.append(from_todo)
+            if to_todo not in to_todos:
+                to_todos.append(to_todo)
+
+        if from_todos and to_todos:
+            if len(from_todos) == 1:
+                following = 'item'
+                depend = 'depends'
+            else:
+                following = 'items'
+                depend = 'depend'
+
+            item = 'item' if len(to_todos) == 1 else 'items'
+
+            self.out('Following todo ' + following + ':')
+            self.out(self.printer.print_list(from_todos))
+            self.out(depend +' now on todo ' + item +' below:')
+            self.out(self.printer.print_list(to_todos))
 
     def _handle_rm(self):
         for from_todo, to_todo in self._get_todos():

--- a/topydo/commands/DepCommand.py
+++ b/topydo/commands/DepCommand.py
@@ -76,16 +76,14 @@ class DepCommand(Command):
             raise InvalidCommandArgument
 
     def _handle_add(self):
-        from_todos = []
-        to_todos = []
+        from_todos = set()
+        to_todos = set()
 
         for from_todo, to_todo in self._get_todos():
             self.todolist.add_dependency(from_todo, to_todo)
 
-            if from_todo not in from_todos:
-                from_todos.append(from_todo)
-            if to_todo not in to_todos:
-                to_todos.append(to_todo)
+            from_todos.add(from_todo)
+            to_todos.add(to_todo)
 
         if from_todos and to_todos:
             if len(from_todos) == 1:
@@ -103,8 +101,30 @@ class DepCommand(Command):
             self.out(self.printer.print_list(to_todos))
 
     def _handle_rm(self):
+        from_todos = set()
+        to_todos = set()
+
         for from_todo, to_todo in self._get_todos():
             self.todolist.remove_dependency(from_todo, to_todo)
+
+            from_todos.add(from_todo)
+            to_todos.add(to_todo)
+
+        if from_todos and to_todos:
+            if len(from_todos) == 1:
+                following = 'item'
+                depend = 'no longer depends'
+            else:
+                following = 'items'
+                depend = 'no longer depend'
+
+            item = 'item' if len(to_todos) == 1 else 'items'
+
+            self.out('Following todo ' + following + ':')
+            self.out(self.printer.print_list(from_todos))
+            self.out(depend + ' on todo ' + item + ' below:')
+            self.out(self.printer.print_list(to_todos))
+
 
     def _get_todos(self):
         result = []

--- a/topydo/commands/DepCommand.py
+++ b/topydo/commands/DepCommand.py
@@ -99,6 +99,8 @@ class DepCommand(Command):
             self.out(self.printer.print_list(from_todos))
             self.out(depend + ' now on todo ' + item + ' below:')
             self.out(self.printer.print_list(to_todos))
+        else:
+            self.out('')
 
     def _handle_rm(self):
         from_todos = set()
@@ -124,7 +126,8 @@ class DepCommand(Command):
             self.out(self.printer.print_list(from_todos))
             self.out(depend + ' on todo ' + item + ' below:')
             self.out(self.printer.print_list(to_todos))
-
+        else:
+            self.out('')
 
     def _get_todos(self):
         result = []

--- a/topydo/ui/columns/Transaction.py
+++ b/topydo/ui/columns/Transaction.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from topydo.lib.MultiCommand import MultiCommand
+from topydo.commands.DepCommand import DepCommand
 
 
 class Transaction(object):
@@ -23,7 +24,7 @@ class Transaction(object):
     todo items.
     """
     def __init__(self, p_subcommand=None, p_env_args=(), p_todo_ids=None):
-        self._multi = issubclass(p_subcommand, MultiCommand)
+        self._multi = issubclass(p_subcommand, (MultiCommand, DepCommand))
         self._cmd = lambda op: p_subcommand(op, *p_env_args)
         self._todo_ids = p_todo_ids
         self._operations = []


### PR DESCRIPTION
1. Add output to `dep add`
2. Add output to `dep rm`
3. Add same operators to all `dep` subsubcommands.
4. Add possibility to use multiple todo items as arguments for all `dep` subsubcommands (like with `topydo.lib.MultiCommand`).

TODO:
- [ ] docstrings
- [ ] update synopsis and help
- [ ] tests
- [ ] think if we can output only **real** removals of the dependencies while performing `dep rm`