### PR TITLE
Move all time-related calls to a special helper

### DIFF
--- a/topydo/commands/AddCommand.py
+++ b/topydo/commands/AddCommand.py
@@ -18,12 +18,12 @@
 
 import codecs
 import re
-from datetime import date
 from os.path import expanduser
 from sys import stdin
 
 from topydo.lib.Config import config
 from topydo.lib.prettyprinters.Numbers import PrettyPrinterNumbers
+from topydo.lib.Time import today
 from topydo.lib.WriteCommand import WriteCommand
 
 
@@ -73,7 +73,7 @@ class AddCommand(WriteCommand):
         self.postprocess_input_todo(todo)
 
         if config().auto_creation_date():
-            todo.set_creation_date(date.today())
+            todo.set_creation_date(today())
 
         self.out(self.printer.print_todo(todo))
 

--- a/topydo/commands/DoCommand.py
+++ b/topydo/commands/DoCommand.py
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import date
-
 from topydo.lib.DCommand import DCommand
 from topydo.lib.printers.PrettyPrinter import PrettyPrinter
 from topydo.lib.Recurrence import NoRecurrenceException, advance_recurring_todo
 from topydo.lib.RelativeDate import relative_date_to_date
+from topydo.lib.Time import today
 from topydo.lib.Utils import date_string_to_date
 
 
@@ -30,7 +29,7 @@ class DoCommand(DCommand):
                  p_prompt=lambda a: None):
 
         self.strict_recurrence = False
-        self.completion_date = date.today()
+        self.completion_date = today()
 
         super().__init__(
             p_args, p_todolist, p_out, p_err, p_prompt)
@@ -56,7 +55,7 @@ class DoCommand(DCommand):
                 if not self.completion_date:
                     self.completion_date = date_string_to_date(p_value)
             except ValueError:
-                self.completion_date = date.today()
+                self.completion_date = today()
 
     def _handle_recurrence(self, p_todo):
         if p_todo.has_tag('rec'):

--- a/topydo/commands/PostponeCommand.py
+++ b/topydo/commands/PostponeCommand.py
@@ -14,12 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from datetime import date, timedelta
+from datetime import timedelta
 
 from topydo.lib.Config import config
 from topydo.lib.MultiCommand import MultiCommand
 from topydo.lib.prettyprinters.Numbers import PrettyPrinterNumbers
 from topydo.lib.RelativeDate import relative_date_to_date
+from topydo.lib.Time import today
 from topydo.lib.Utils import date_string_to_date
 
 
@@ -44,12 +45,12 @@ class PostponeCommand(MultiCommand):
     def _execute_multi_specific(self):
         def _get_offset(p_todo):
             offset = p_todo.tag_value(
-                config().tag_due(), date.today().isoformat())
+                config().tag_due(), today().isoformat())
 
             offset_date = date_string_to_date(offset)
 
-            if offset_date < date.today():
-                offset_date = date.today()
+            if offset_date < today():
+                offset_date = today()
 
             return offset_date
 

--- a/topydo/lib/Config.py
+++ b/topydo/lib/Config.py
@@ -73,6 +73,7 @@ class _Config:
                 'identifiers': 'linenumber',
                 'identifier_alphabet': '0123456789abcdefghijklmnopqrstuvwxyz',
                 'backup_count': '5',
+                'time_shift': '0',
             },
 
             'add': {
@@ -259,6 +260,12 @@ class _Config:
             return value
         except ValueError:
             return int(self.defaults['topydo']['backup_count'])
+
+    def time_shift(self):
+        try:
+            return self.cp.getint('topydo', 'time_shift')
+        except ValueError:
+            return int(self.defaults['topydo']['time_shift'])
 
     def list_limit(self):
         try:

--- a/topydo/lib/Importance.py
+++ b/topydo/lib/Importance.py
@@ -23,9 +23,8 @@ today may have a higher importance than high priority tasks in the distant
 future.
 """
 
-from datetime import date
-
 from topydo.lib.Config import config
+from topydo.lib.Time import today
 
 IMPORTANCE_VALUE = {'A': 3, 'B': 2, 'C': 1}
 
@@ -34,10 +33,10 @@ def is_due_next_monday(p_todo):
     """ Returns True when today is Friday (or the weekend) and the given task
     is due next Monday.
     """
-    today = date.today()
+    today_ = today()
     due = p_todo.due_date()
 
-    return due and due.weekday() == 0 and today.weekday() >= 4 and \
+    return due and due.weekday() == 0 and today_.weekday() >= 4 and \
         p_todo.days_till_due() <= 3
 
 

--- a/topydo/lib/ListFormat.py
+++ b/topydo/lib/ListFormat.py
@@ -18,10 +18,9 @@
 
 import re
 
-import arrow
-
 from topydo.lib.Config import config
 from topydo.lib.ProgressColor import progress_color
+from topydo.lib.Time import today
 from topydo.lib.Utils import escape_ansi, get_terminal_size, humanize_date
 
 MAIN_PATTERN = (r'^({{(?P<before>.+?)}})?'
@@ -54,7 +53,7 @@ def humanize_dates(p_due=None, p_start=None, p_creation=None):
     if p_due:
         dates_list.append('due ' + humanize_date(p_due))
     if p_start:
-        now = arrow.now().date()
+        now = today()
         dates_list.append('{} {}'.format(
             'started' if p_start <= now else 'starts',
             humanize_date(p_start)

--- a/topydo/lib/Recurrence.py
+++ b/topydo/lib/Recurrence.py
@@ -16,10 +16,11 @@
 
 """ This module deals with recurring tasks. """
 
-from datetime import date, timedelta
+from datetime import timedelta
 
 from topydo.lib.Config import config
 from topydo.lib.RelativeDate import relative_date_to_date
+from topydo.lib.Time import today
 from topydo.lib.Todo import Todo
 
 
@@ -51,9 +52,9 @@ def advance_recurring_todo(p_todo, p_offset=None, p_strict=False):
         pattern = pattern[1:]
 
     if p_strict:
-        offset = p_todo.due_date() or p_offset or date.today()
+        offset = p_todo.due_date() or p_offset or today()
     else:
-        offset = p_offset or date.today()
+        offset = p_offset or today()
 
     length = todo.length()
     new_due = relative_date_to_date(pattern, offset)
@@ -68,6 +69,6 @@ def advance_recurring_todo(p_todo, p_offset=None, p_strict=False):
         new_start = new_due - timedelta(length)
         todo.set_tag(config().tag_start(), new_start.isoformat())
 
-    todo.set_creation_date(date.today())
+    todo.set_creation_date(today())
 
     return todo

--- a/topydo/lib/RelativeDate.py
+++ b/topydo/lib/RelativeDate.py
@@ -20,6 +20,8 @@ import calendar
 import re
 from datetime import date, timedelta
 
+from topydo.lib.Time import today
+
 
 def _add_months(p_sourcedate, p_months):
     """
@@ -61,7 +63,7 @@ def _convert_pattern(p_length, p_periodunit, p_offset=None):
     """
     result = None
 
-    p_offset = p_offset or date.today()
+    p_offset = p_offset or today()
     p_length = int(p_length)
 
     if p_periodunit == 'd':
@@ -97,10 +99,10 @@ def _convert_weekday_pattern(p_weekday):
     target_day_string = p_weekday[:2].lower()
     target_day = day_value[target_day_string]
 
-    day = date.today().weekday()
+    day = today().weekday()
 
     shift = 7 - (day - target_day) % 7
-    return date.today() + timedelta(shift)
+    return today() + timedelta(shift)
 
 
 def relative_date_to_date(p_date, p_offset=None):
@@ -115,7 +117,7 @@ def relative_date_to_date(p_date, p_offset=None):
     """
     result = None
     p_date = p_date.lower()
-    p_offset = p_offset or date.today()
+    p_offset = p_offset or today()
 
     relative = re.match('(?P<length>-?[0-9]+)(?P<period>[dwmyb])$',
                         p_date, re.I)

--- a/topydo/lib/Time.py
+++ b/topydo/lib/Time.py
@@ -16,11 +16,13 @@
 
 """ This module provides functions that deal with time. """
 
-from datetime import date
 import arrow
+from datetime import datetime, timedelta
+
+from topydo.lib.Config import config
 
 def today():
-    return date.today()
+    return (datetime.now() - timedelta(hours=config().time_shift())).date()
 
 def humanize(p_datetime):
     return arrow.get(str(p_datetime)) \

--- a/topydo/lib/Time.py
+++ b/topydo/lib/Time.py
@@ -1,0 +1,28 @@
+# Topydo - A todo.txt client written in Python.
+# Copyright (C) 2018 Leo Gaspard <topydo@leo.gaspard.ninja>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+""" This module provides functions that deal with time. """
+
+from datetime import date
+import arrow
+
+def today():
+    return date.today()
+
+def humanize(p_datetime):
+    return arrow.get(str(p_datetime)) \
+                .humanize(other=arrow.get(str(today()))) \
+                .replace('just now', 'today')

--- a/topydo/lib/Todo.py
+++ b/topydo/lib/Todo.py
@@ -18,9 +18,8 @@
 This module provides the Todo class.
 """
 
-from datetime import date
-
 from topydo.lib.Config import config
+from topydo.lib.Time import today
 from topydo.lib.TodoBase import TodoBase
 from topydo.lib.Utils import date_string_to_date
 
@@ -61,7 +60,7 @@ class Todo(TodoBase):
         task has not yet been completed.
         """
         start = self.start_date()
-        return not self.is_completed() and (not start or start <= date.today())
+        return not self.is_completed() and (not start or start <= today())
 
     def is_overdue(self):
         """
@@ -78,7 +77,7 @@ class Todo(TodoBase):
         """
         due = self.due_date()
         if due:
-            diff = due - date.today()
+            diff = due - today()
             return diff.days
         return 0
 

--- a/topydo/lib/TodoBase.py
+++ b/topydo/lib/TodoBase.py
@@ -19,8 +19,8 @@ This module contains the class that represents a single todo item.
 """
 
 import re
-from datetime import date
 
+from topydo.lib.Time import today
 from topydo.lib.TodoParser import parse_line
 from topydo.lib.Utils import is_valid_priority
 
@@ -198,7 +198,7 @@ class TodoBase(object):
         """
         return self.fields['completionDate']
 
-    def set_completed(self, p_completion_date=date.today()):
+    def set_completed(self, p_completion_date=today()):
         """
         Marks the todo as complete.
         Sets the completed flag and sets the completion date to today.
@@ -213,7 +213,7 @@ class TodoBase(object):
                               'x ' + p_completion_date.isoformat() + ' ',
                               self.src)
 
-    def set_creation_date(self, p_date=date.today()):
+    def set_creation_date(self, p_date=today()):
         """
         Sets the creation date of a todo. Should be passed a date object.
         """

--- a/topydo/lib/TodoFileWatched.py
+++ b/topydo/lib/TodoFileWatched.py
@@ -21,11 +21,10 @@ changes.
 
 import os.path
 
+from topydo.lib.TodoFile import TodoFile
 from watchdog.events import (FileCreatedEvent, FileModifiedEvent,
                              FileSystemEventHandler)
 from watchdog.observers import Observer
-
-from topydo.lib.TodoFile import TodoFile
 
 
 class TodoFileWatched(TodoFile):

--- a/topydo/lib/TodoListBase.py
+++ b/topydo/lib/TodoListBase.py
@@ -20,12 +20,12 @@ A list of todo items.
 
 import math
 import re
-from datetime import date
 
 from topydo.lib import Filter
 from topydo.lib.Config import config
 from topydo.lib.HashListValues import hash_list_values, max_id_length
 from topydo.lib.printers.PrettyPrinter import PrettyPrinter
+from topydo.lib.Time import today
 from topydo.lib.Todo import Todo
 from topydo.lib.View import View
 
@@ -239,7 +239,7 @@ class TodoListBase(object):
     def todos(self):
         return self._todos
 
-    def set_todo_completed(self, p_todo, p_completion_date=date.today()):
+    def set_todo_completed(self, p_todo, p_completion_date=today()):
         p_todo.set_completed(p_completion_date)
         self.dirty = True
 

--- a/topydo/lib/Utils.py
+++ b/topydo/lib/Utils.py
@@ -22,7 +22,7 @@ import re
 from collections import namedtuple
 from datetime import date
 
-import arrow
+from topydo.lib.Time import humanize
 
 
 def date_string_to_date(p_date):
@@ -111,6 +111,4 @@ def translate_key_to_config(p_key):
 
 def humanize_date(p_datetime):
     """ Returns a relative date string from a datetime object. """
-    now = arrow.now()
-    _date = now.replace(day=p_datetime.day, month=p_datetime.month, year=p_datetime.year)
-    return _date.humanize(now).replace('just now', 'today')
+    return humanize(p_datetime)

--- a/topydo/ui/CompleterBase.py
+++ b/topydo/ui/CompleterBase.py
@@ -14,11 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
 from functools import lru_cache
 
 from topydo.Commands import SUBCOMMAND_MAP
 from topydo.lib.Config import config
+from topydo.lib.Time import today
 
 
 @lru_cache(maxsize=1)
@@ -51,7 +51,7 @@ def date_suggestions():
     ]
 
     # show days of week up to next week
-    dow = datetime.date.today().weekday()
+    dow = today().weekday()
     for i in range(dow + 2 % 7, dow + 7):
         dates.append(days_of_week[i % 7])
 


### PR DESCRIPTION
This moves (hopefully) all the code that calls date-related functions to a special helper file.

This should be the first move to support moving the midnight barrier, for https://github.com/bram85/topydo/issues/227: now, there is a centralized place to offset the day if required.

These changes don't break any test here, then it's not adding any feature yet, so that was to be expected.