### PR TITLE
Change the implicit default priority to 'M'

### DIFF
--- a/topydo/lib/Sorter.py
+++ b/topydo/lib/Sorter.py
@@ -63,7 +63,7 @@ FIELDS = {
         label='Length',
     ),
     'priority': Field(
-        sort=(lambda t: t.priority() or 'ZZ'),
+        sort=(lambda t: t.priority() or 'M'),
         group=(lambda t: t.priority() or 'None'),
         label='Priority',
     ),


### PR DESCRIPTION
So that priorities later in the alphabet can be used to push tasks
below the unprioritized ones.

I want 'Z' priority tasks at the bottom of the list.