### PR TITLE
Remove unused requirement of pytest-runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "pytest-runner"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
Building the topydo package on OpenBSD we found the requirement of pytest-runner is not needed.

Even make test did succeed 100%.

If there is no need for this in other systems, it can be removed.